### PR TITLE
Broaden taxonomy, harden infrastructure, split references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .claude/
 TODO.md
 IDEAS.md
+PROPOSALS.md
 data/
 *.swp
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
 .DS_Store
 .claude/
 TODO.md
+IDEAS.md
 data/
+*.swp
+*.log
+.idea/
+.vscode/
+.env

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Each new `.m4a` in your Voice Memos iCloud sync dir is classified into one of tw
 | State                | Action                                                             |
 | -------------------- | ------------------------------------------------------------------ |
 | `INSTRUCTION_DIRECT` | Carry out the instruction, report back                             |
-| `INSTRUCTION_ADD`    | Open a GitHub issue on this repo with the proposed rule            |
+| `INSTRUCTION_ADD`    | Record a rule proposal in `PROPOSALS.md` with a suggested patch    |
 | `INSTRUCTION_UNSURE` | Ask the user to confirm **and** file a disambiguating example      |
 | `TODO_ADAM`          | Create an Apple Reminder in the default (Siri) list                |
 | `TODO_ASSISTANT`     | Append to `TODO.md` in this skill's directory                      |
@@ -65,7 +65,6 @@ classify (+ confidence) → dedup check → archive → act → audit
 - macOS (tested on Apple Silicon; should work on Intel)
 - [openclaw](https://openclaw.ai) installed and onboarded (`openclaw onboard`)
 - Messaging channel configured in openclaw (`openclaw channels add`) — the skill reports back via your primary channel
-- `gh` authenticated (`gh auth status`) with `repo` scope — needed for `INSTRUCTION_ADD` / `INSTRUCTION_UNSURE`
 - Voice Memos signed into the same iCloud account as your iPhone, with iCloud sync enabled (System Settings → Apple ID → iCloud → Voice Memos)
 - Mac mini stays awake, or is set to wake for network access
 
@@ -79,7 +78,7 @@ cd skill-apple-voice-assistant
 
 The installer:
 
-1. Validates prerequisites (`openclaw`, `gh`, `osascript`, gh auth)
+1. Validates prerequisites (`openclaw`, `osascript`)
 2. Symlinks this repo into `~/.openclaw/workspace/skills/apple_voice_assistant`
 3. Renders and bootstraps the launchd watcher (fires on directory changes)
 4. Installs a daily health check (09:00 — alerts if the watcher has gone silent)
@@ -103,7 +102,7 @@ rm ~/.openclaw/workspace/skills/apple_voice_assistant
 
 ## Teaching it new rules
 
-Record a memo describing the new rule (e.g. "when I say 'remind me to X', always treat that as a `TODO_ADAM`, never `TODO_ASSISTANT`"). If classified as `INSTRUCTION_ADD`, openclaw will open a GitHub issue here proposing the edit to `SKILL.md`. Review, merge, done — next run picks up the new rule.
+Record a memo describing the new rule (e.g. "when I say 'remind me to X', always treat that as a `TODO_ADAM`, never `TODO_ASSISTANT`"). If classified as `INSTRUCTION_ADD`, openclaw will append a proposal to `PROPOSALS.md` with a suggested patch for `SKILL.md` or the classification examples. Review, apply, done — next run picks up the new rule.
 
 Classification examples live in [`references/classification-examples.md`](references/classification-examples.md) and grow over time as the teaching loop proposes new patterns.
 

--- a/README.md
+++ b/README.md
@@ -2,33 +2,41 @@
 
 An [openclaw](https://openclaw.ai) skill that turns iPhone voice memos into actions.
 
-Record a memo on your phone. iCloud syncs it to your Mac mini. A launchd watcher fires openclaw. openclaw transcribes natively, classifies the intent, and either does the thing, asks you about it, or files it for later — reporting back on Matrix.
+Record a memo on your phone. iCloud syncs it to your Mac mini. A launchd watcher fires openclaw. openclaw transcribes natively, classifies the intent, and either does the thing, asks you about it, or files it for later — reporting back via your configured messaging channel.
 
 ## What it does
 
-Each new `.m4a` in your Voice Memos iCloud sync dir is classified into one of six states, each with its own action:
+Each new `.m4a` in your Voice Memos iCloud sync dir is classified into one of twelve states, each with its own action:
 
-| State                | Action                                                            |
-| -------------------- | ----------------------------------------------------------------- |
-| `UNKNOWN`            | Ask on Matrix how to categorize                                   |
-| `INSTRUCTION_ADD`    | Open a GitHub issue on this repo with the proposed rule           |
-| `INSTRUCTION_DIRECT` | Carry out the instruction, report back on Matrix                  |
-| `INSTRUCTION_UNSURE` | Ask on Matrix **and** file an issue with a disambiguating example |
-| `TODO_ADAM`          | Create an Apple Reminder in the default (Siri) list               |
-| `TODO_ASSISTANT`     | Append to `TODO.md` in this repo                                  |
+| State                | Action                                                             |
+| -------------------- | ------------------------------------------------------------------ |
+| `INSTRUCTION_DIRECT` | Carry out the instruction, report back                             |
+| `INSTRUCTION_ADD`    | Open a GitHub issue on this repo with the proposed rule            |
+| `INSTRUCTION_UNSURE` | Ask the user to confirm **and** file a disambiguating example      |
+| `TODO_ADAM`          | Create an Apple Reminder in the default (Siri) list                |
+| `TODO_ASSISTANT`     | Append to `TODO.md` in this skill's directory                      |
+| `MEMORY_NOTE`        | Write to the runtime's memory system                               |
+| `JOURNAL_NOTE`       | Archive only — raw thoughts, reflections                           |
+| `IDEA_CAPTURE`       | Archive + append to `IDEAS.md`                                     |
+| `RESEARCH_REQUEST`   | File a research task (don't act immediately)                       |
+| `MESSAGE_DRAFT`      | Draft a message, **never** send without confirmation               |
+| `TRANSCRIBE_ONLY`    | Archive transcript, no action                                      |
+| `UNKNOWN`            | Ask how to categorize — feeds the classification training pipeline |
 
-All six actions produce a Matrix message so nothing disappears silently. See [`SKILL.md`](SKILL.md) for the full classification rules.
+Every classification also carries a **confidence level** (`high`/`medium`/`low`). Low-confidence classifications never trigger external or irreversible actions.
+
+All states produce an audit message so nothing disappears silently. See [`SKILL.md`](SKILL.md) for the workflow and [`references/`](references/) for classification examples, action specs, and archive format.
 
 Every memo is also archived into this skill's own `data/` tree, organized by date:
 
 ```
 data/YYYY/MM/DD/HH-MM-SS-<slug>.m4a    # copy of the original audio
-data/YYYY/MM/DD/HH-MM-SS-<slug>.md     # transcript + metadata (source path, category, action taken)
+data/YYYY/MM/DD/HH-MM-SS-<slug>.md     # transcript + metadata (source path, category, confidence, action taken)
 ```
 
 Where `<slug>` is a 2–6-word lowercase summary derived from the transcript (e.g. `08-30-45-grocery-list-for-saturday.m4a`) so you can find a memo by skimming filenames.
 
-`data/` is git-ignored — the archive is a local history on whichever machine the skill runs on, not something to sync to GitHub.
+`data/` is git-ignored — the archive is a local history on whichever machine the skill runs on.
 
 ## Architecture
 
@@ -43,19 +51,20 @@ Mac mini: ~/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recording
         │   launchd WatchPaths fires
         ▼
 install/watcher.sh
-        │   diffs against seen-set, emits one openclaw call per new memo
+        │   acquires lock, validates file stability, diffs against seen-set
+        │   emits one openclaw call per new memo (with timeout)
         ▼
 openclaw agent --message "new voice memo at <path>"
         │   loads SKILL.md, attaches audio, native Whisper transcribes
         ▼
-classify → act → report on Matrix
+classify (+ confidence) → dedup check → archive → act → audit
 ```
 
 ## Prerequisites
 
 - macOS (tested on Apple Silicon; should work on Intel)
 - [openclaw](https://openclaw.ai) installed and onboarded (`openclaw onboard`)
-- Matrix channel configured in openclaw (`openclaw channels add`) — the skill assumes openclaw knows how to reach you
+- Messaging channel configured in openclaw (`openclaw channels add`) — the skill reports back via your primary channel
 - `gh` authenticated (`gh auth status`) with `repo` scope — needed for `INSTRUCTION_ADD` / `INSTRUCTION_UNSURE`
 - Voice Memos signed into the same iCloud account as your iPhone, with iCloud sync enabled (System Settings → Apple ID → iCloud → Voice Memos)
 - Mac mini stays awake, or is set to wake for network access
@@ -70,10 +79,11 @@ cd skill-apple-voice-assistant
 
 The installer:
 
-1. Symlinks this repo into `~/.openclaw/workspace/skills/apple_voice_assistant`
-2. Renders `install/com.cyclingwithelephants.apple-voice-assistant.plist` into `~/Library/LaunchAgents/`
-3. Bootstraps the launchd job
-4. Seeds the seen-set with existing memos so your history doesn't get re-processed
+1. Validates prerequisites (`openclaw`, `gh`, `osascript`, gh auth)
+2. Symlinks this repo into `~/.openclaw/workspace/skills/apple_voice_assistant`
+3. Renders and bootstraps the launchd watcher (fires on directory changes)
+4. Installs a daily health check (09:00 — alerts if the watcher has gone silent)
+5. Seeds the seen-set with existing memos so your history doesn't get re-processed
 
 Record a new memo on your iPhone. Tail the log to confirm:
 
@@ -84,8 +94,10 @@ tail -f ~/.local/state/apple-voice-assistant/watcher.log
 ## Uninstall
 
 ```bash
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.cyclingwithelephants.apple-voice-assistant.plist
-rm ~/Library/LaunchAgents/com.cyclingwithelephants.apple-voice-assistant.plist
+DOMAIN="gui/$(id -u)"
+launchctl bootout "${DOMAIN}" ~/Library/LaunchAgents/com.cyclingwithelephants.apple-voice-assistant.plist
+launchctl bootout "${DOMAIN}" ~/Library/LaunchAgents/com.cyclingwithelephants.apple-voice-assistant-healthcheck.plist
+rm ~/Library/LaunchAgents/com.cyclingwithelephants.apple-voice-assistant*.plist
 rm ~/.openclaw/workspace/skills/apple_voice_assistant
 ```
 
@@ -93,11 +105,18 @@ rm ~/.openclaw/workspace/skills/apple_voice_assistant
 
 Record a memo describing the new rule (e.g. "when I say 'remind me to X', always treat that as a `TODO_ADAM`, never `TODO_ASSISTANT`"). If classified as `INSTRUCTION_ADD`, openclaw will open a GitHub issue here proposing the edit to `SKILL.md`. Review, merge, done — next run picks up the new rule.
 
+Classification examples live in [`references/classification-examples.md`](references/classification-examples.md) and grow over time as the teaching loop proposes new patterns.
+
 ## Files
 
-- [`SKILL.md`](SKILL.md) — the skill itself (classification rules + actions)
-- [`install/watcher.sh`](install/watcher.sh) — launchd-fired shell script that diffs new memos and invokes openclaw
-- [`install/com.cyclingwithelephants.apple-voice-assistant.plist`](install/com.cyclingwithelephants.apple-voice-assistant.plist) — launchd agent template
+- [`SKILL.md`](SKILL.md) — the skill core (workflow, safety rules, classification states)
+- [`references/classification-examples.md`](references/classification-examples.md) — worked examples for classification
+- [`references/actions.md`](references/actions.md) — what each state does
+- [`references/archive-format.md`](references/archive-format.md) — archive directory layout and transcript metadata spec
+- [`install/watcher.sh`](install/watcher.sh) — launchd-fired shell script (lock, stability check, timeout, seen-set diff)
+- [`install/healthcheck.sh`](install/healthcheck.sh) — daily health check (alerts if watcher goes silent)
+- [`install/com.cyclingwithelephants.apple-voice-assistant.plist`](install/com.cyclingwithelephants.apple-voice-assistant.plist) — launchd watcher agent
+- [`install/com.cyclingwithelephants.apple-voice-assistant-healthcheck.plist`](install/com.cyclingwithelephants.apple-voice-assistant-healthcheck.plist) — launchd health check agent
 - [`install/install.sh`](install/install.sh) — wires it all up
 
 ## License

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,14 +1,7 @@
 ---
-name: apple_voice_assistant
-description: Process an iPhone voice memo — categorize its intent (instruction, todo, new rule, unknown) and take the appropriate action. Triggered when a new Apple Voice Memo lands on the Mac mini via iCloud sync.
+name: apple-voice-assistant
+description: Process an iPhone voice memo — classify intent, act on it, archive, and report back.
 homepage: https://github.com/cyclingwithelephants/skill-apple-voice-assistant
-metadata:
-  openclaw:
-    os: darwin
-    requires:
-      bins:
-        - gh
-        - osascript
 ---
 
 # Apple Voice Assistant
@@ -21,7 +14,7 @@ You process iPhone voice memos on behalf of the user (Adam, GitHub `cyclingwithe
 
 Extract the absolute path from the triggering message (e.g. `/Users/adam/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/20260419 083045.m4a`).
 
-Explicitly read the file and attach it to the conversation so your native audio transcription runs over it. Do not assume the audio is already loaded — call your `read` tool on the path first, then rely on the resulting `{{Transcript}}` variable / `[Audio]` block for the memo body.
+Explicitly read the file and attach it to the conversation so your native audio transcription runs over it. Do not assume the audio is already loaded — call your `read` tool on the path first, then rely on the resulting transcript for the memo body.
 
 Validate before proceeding:
 
@@ -29,151 +22,116 @@ Validate before proceeding:
 - file ends in `.m4a` (skip `.icloud` placeholders — they mean iCloud hasn't finished syncing yet; if you see one, log and stop, the launchd watcher will retry on the next change)
 - transcript is non-empty
 
-If any check fails, send the user a Matrix message explaining the problem and stop.
+If any check fails, send the user a message explaining the problem and stop.
 
-## Step 2 — Categorize the transcript
+## Step 2 — Classify the transcript
 
-Classify into exactly one state:
+Assign exactly one **state** and one **confidence level**.
+
+### States
 
 | State                | Meaning                                                                                                         |
 | -------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `UNKNOWN`            | No clear intent — doesn't match any other state                                                                 |
-| `INSTRUCTION_ADD`    | User is teaching a new rule, pattern, or example for this skill itself                                          |
 | `INSTRUCTION_DIRECT` | A direct instruction for you to carry out now                                                                   |
+| `INSTRUCTION_ADD`    | User is teaching a new rule, pattern, or example for this skill itself                                          |
 | `INSTRUCTION_UNSURE` | Sounds like a direct instruction but you're not confident — ambiguous scope, missing context, or novel phrasing |
 | `TODO_ADAM`          | A task the user wants to do themselves later                                                                    |
 | `TODO_ASSISTANT`     | A task the user wants you to do later (not now)                                                                 |
+| `MEMORY_NOTE`        | A fact to persist — about a person, project, system, or preference                                              |
+| `JOURNAL_NOTE`       | Raw thoughts, reflections, life log — no action needed beyond archiving                                         |
+| `IDEA_CAPTURE`       | A product, project, or creative idea to capture for later                                                       |
+| `RESEARCH_REQUEST`   | "Look into X" — create a research task, do NOT act immediately                                                  |
+| `MESSAGE_DRAFT`      | "Send/tell/reply to Y" — draft a message, never send without explicit confirmation                              |
+| `TRANSCRIBE_ONLY`    | User explicitly says "just save this" or similar — archive only, no action                                      |
+| `UNKNOWN`            | No clear intent — doesn't match any other state                                                                 |
 
-Bias toward `INSTRUCTION_UNSURE` over `INSTRUCTION_DIRECT` when in doubt — it's cheaper to ask than to act wrongly. Bias toward `TODO_ADAM` over `TODO_ASSISTANT` when the actor is unclear — Adam defaults to owning his own work.
+`UNKNOWN` is the **classification training pipeline**. Its purpose is to collect memos that don't fit existing states so patterns can be discovered over time and new states or rules proposed. It is not a generic fallback bin — classify into a specific state whenever possible, and only use `UNKNOWN` when the memo genuinely doesn't match anything above.
 
-## Step 3 — Archive the audio and transcript
+### Classification biases
 
-Copy the raw audio and write a matching transcript file into this skill's own `data/` tree, organized by date. This gives a durable, greppable history independent of Voice Memos / iCloud and survives any upstream deletion.
+- Prefer `INSTRUCTION_UNSURE` over `INSTRUCTION_DIRECT` when in doubt — cheaper to ask than to act wrongly.
+- Prefer `TODO_ADAM` over `TODO_ASSISTANT` when the actor is unclear — Adam defaults to owning his own work.
+- Prefer `MEMORY_NOTE` over `JOURNAL_NOTE` when the memo contains a concrete fact, even if it's embedded in a reflection.
+- Prefer a specific state over `UNKNOWN` — `UNKNOWN` is for genuinely unclassifiable memos, not "I'm not sure."
 
-### Derive the timestamp
+See [`references/classification-examples.md`](references/classification-examples.md) for worked examples covering common and edge-case phrasings.
 
-Prefer the timestamp embedded in the Voice Memos filename — the app names recordings like `YYYYMMDD HHMMSS.m4a` (e.g. `20260419 083045.m4a`). Parse out year, month, day, hour, minute, and second components from the filename, then format as `YYYY/MM/DD` for the directory path and `HH-MM-SS` for the filename prefix.
+### Confidence
 
-If the filename doesn't follow that pattern, fall back to the file's mtime via `stat -f %m <path>`.
+Rate your classification confidence as `high`, `medium`, or `low`.
 
-### Derive a short summary slug
+| Confidence | Meaning                                               | Constraint                                                                                                                                                               |
+| ---------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `high`     | Clear intent, unambiguous phrasing                    | No restrictions                                                                                                                                                          |
+| `medium`   | Likely correct but some ambiguity                     | Proceed, but note uncertainty in audit message                                                                                                                           |
+| `low`      | Guessing — transcript is noisy, garbled, or ambiguous | **Never perform external or irreversible actions.** Escalate to draft/confirm. Treat as `INSTRUCTION_UNSURE` if it looked like an instruction, or archive-only otherwise |
 
-Also generate a short human-readable slug from the transcript so archived files are self-describing at a glance.
+Voice-to-text errors are common. A misheard word can completely change intent. When confidence is low, the cost of asking is always lower than the cost of acting wrongly.
 
-Rules for the slug:
+## Step 3 — Check for duplicates
 
-- 2–6 words, all lowercase, hyphen-separated
-- describe the topic or action, not the form (good: `grocery-list-for-saturday`, bad: `voice-memo-about-groceries`)
-- strip all non-ASCII-alphanumeric characters before hyphenating (spaces, punctuation, emoji, accents → gone)
-- cap total slug length at 50 characters — truncate at the nearest hyphen rather than mid-word
-- if the transcript is too empty or noisy to produce a meaningful slug, use `untitled`
-
-### Write both files
-
-The skill's own directory is at `~/.openclaw/workspace/skills/apple_voice_assistant/`. Archive under its `data/` subtree, with the slug appended to both filenames so audio and transcript pair by name:
-
-```
-data/YYYY/MM/DD/HH-MM-SS-<slug>.m4a      # copy of the original audio, extension preserved
-data/YYYY/MM/DD/HH-MM-SS-<slug>.md       # transcript + metadata
-```
-
-For example: `data/2026/04/19/08-30-45-grocery-list-for-saturday.m4a` + `data/2026/04/19/08-30-45-grocery-list-for-saturday.md`.
-
-Create any missing intermediate directories with `mkdir -p`. The audio and transcript must share the same `HH-MM-SS-<slug>` stem — never drift.
-
-**Audio**: `cp` (never `mv`) from the source path — iCloud owns the Voice Memos file lifecycle and moving would break the app. Preserve the original extension (normally `.m4a`, but don't assume — derive from the source path).
-
-**Transcript**: a Markdown file with YAML frontmatter followed by the full transcript body. Use this structure:
-
-```markdown
----
-source_path: /Users/adam/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/20260419 083045.m4a
-recorded_at: 2026-04-19T08:30:45Z
-archived_at: 2026-04-19T08:31:02Z
-duration_seconds: 47
-category: INSTRUCTION_UNSURE
-action_taken: filed GitHub issue #12 + Matrix message
----
-
-<full transcript verbatim>
-```
-
-Include whichever frontmatter fields you have information for — `duration_seconds` is optional, `source_path` / `recorded_at` / `archived_at` / `category` are required. `action_taken` is filled in after Step 4 completes (either update the file or append it at the end; updating is fine).
-
-### If archiving fails
-
-If the `cp` or transcript write fails (disk full, permission denied, etc.), log it and continue to Step 4 anyway — the action the user intended should still happen. Include the failure in the Matrix audit message.
-
-## Step 4 — Act on the category
-
-### `UNKNOWN`
-
-Send the user a Matrix message containing the full transcript and ask how to categorize it. Do nothing else.
-
-### `INSTRUCTION_ADD`
-
-Open a GitHub issue on `cyclingwithelephants/skill-apple-voice-assistant` capturing the proposed rule/example. Use `gh issue create` with:
-
-- title: one-line summary of the rule (prefix `instruction: `)
-- body: full transcript + your interpretation of what the rule means + suggested edit location in `SKILL.md` + a reference to the archived transcript path from Step 3
-
-Send the user a short Matrix message confirming the issue URL.
-
-### `INSTRUCTION_DIRECT`
-
-Carry out the instruction using your normal tool set (bash, browser, read/write, etc.). When finished — or if you hit a blocker — send a Matrix message reporting what you did and any result/output.
-
-### `INSTRUCTION_UNSURE`
-
-Do two things:
-
-1. Send a Matrix message quoting the transcript and asking the user to confirm the intended action. Offer the best-guess interpretation.
-2. Follow the `INSTRUCTION_ADD` action to file a GitHub issue proposing an example that would have disambiguated this memo — so next time a similar phrasing lands, you'd classify it confidently. Reference the Matrix message in the issue.
-
-### `TODO_ADAM`
-
-Create an Apple Reminder in the user's default Reminders list (the list Siri uses by default — don't specify a list name). Use `osascript` with AppleScript:
-
-```applescript
-tell application "Reminders"
-  set newReminder to make new reminder with properties {name:"<short title>", body:"<context/notes>"}
-end tell
-```
-
-Where:
-
-- `name`: a concise imperative title derived from the transcript
-- `body`: any useful context from the memo (who, when, why) — include the full transcript at the bottom so nothing is lost
-
-Send the user a Matrix message confirming the reminder was added.
-
-### `TODO_ASSISTANT`
-
-Append a line to `TODO.md` at the root of this directory (`~/.openclaw/workspace/skills/apple_voice_assistant/TODO.md` when installed locally). Format:
+Before archiving or acting, check whether this memo has already been processed. The watcher writes an idempotency record for each processed memo at:
 
 ```
-- [ ] YYYY-MM-DD <short title> — <one-line context>. Archive: data/YYYY/MM/DD/HH-MM-SS-<slug>.md
+~/.local/state/apple-voice-assistant/processed/<memo_id>.json
 ```
 
-If `TODO.md` doesn't exist, create it. Send the user a Matrix message confirming the task was added.
+Where `<memo_id>` is derived from the source filename (basename without extension). If a record already exists with the same `source_mtime` and `source_size_bytes`, skip this memo — it's a duplicate triggered by iCloud sync churn.
 
-## Step 5 — Always leave an audit trail
+If no record exists, create one after Step 5 completes:
 
-Every run must produce at least one Matrix message to the user so nothing disappears silently. If an action fails (e.g. `gh` not authed, Reminders permission denied, archive write failed), send a Matrix message with the error and the raw transcript.
+```json
+{
+  "memo_id": "20260419 083045",
+  "source_filename": "20260419 083045.m4a",
+  "source_mtime": 1745053845,
+  "source_size_bytes": 234567,
+  "category": "TODO_ADAM",
+  "confidence": "high",
+  "archive_path": "data/2026/04/19/08-30-45-grocery-list-for-saturday.md",
+  "disposition": "created Apple Reminder",
+  "processed_at": "2026-04-19T08:31:02Z"
+}
+```
 
-**If the Matrix send itself fails** (network error, openclaw channel misconfigured, homeserver down, etc.) you cannot rely on the user ever seeing this run. Append a self-chase item to `TODO.md` at the root of this directory so you remember to surface it next time you run successfully. Format:
+## Step 4 — Archive the audio and transcript
+
+Copy the raw audio and write a matching transcript file into this skill's `data/` tree. This gives a durable, greppable history independent of Voice Memos / iCloud.
+
+See [`references/archive-format.md`](references/archive-format.md) for the full archive specification (directory layout, slug rules, transcript frontmatter fields, failure handling).
+
+## Step 5 — Act on the category
+
+Each state maps to a specific action. See [`references/actions.md`](references/actions.md) for the full action specification.
+
+### Safety rules (apply to ALL states)
+
+1. **Never send, post, or publish externally without confirmation.** Any action that sends a message to another person, creates a public GitHub issue outside this repo, posts to a channel, or emails — default to **draft + confirm**. This applies to `MESSAGE_DRAFT` by definition, but also to any `INSTRUCTION_DIRECT` that involves external communication. Voice memos are too easy to underspecify.
+
+2. **Low confidence = no irreversible actions.** If confidence is `low`, do not execute instructions, create external resources, or send messages. Archive the transcript and ask the user for clarification.
+
+3. **Never delete or move the source `.m4a`.** iCloud owns that lifecycle; archiving is always a copy.
+
+## Step 6 — Audit trail
+
+Every run must produce at least one message to the user so nothing disappears silently. Use whatever messaging channel the runtime provides (e.g. the primary notification channel configured in the host). Do not hardcode a specific channel.
+
+The audit message should include: transcript summary, category, confidence, action taken, and archive path.
+
+If an action fails (e.g. `gh` not authed, Reminders permission denied, archive write failed), send a message with the error and the raw transcript.
+
+**If the message send itself fails** (network error, channel misconfigured, etc.), append a self-chase item to `TODO.md` at the root of this skill's directory:
 
 ```
-- [ ] YYYY-MM-DD FOLLOW-UP — failed to notify user about memo. Archive: data/YYYY/MM/DD/HH-MM-SS-<slug>.md. Category: <STATE>. Action taken: <summary or "none">. Error: <matrix error>.
+- [ ] YYYY-MM-DD FOLLOW-UP — failed to notify user about memo. Archive: data/YYYY/MM/DD/HH-MM-SS-<slug>.md. Category: <STATE>. Confidence: <level>. Action taken: <summary or "none">. Error: <error>.
 ```
 
-On every subsequent run, before Step 1, scan `TODO.md` for `FOLLOW-UP` items and include a short "unresolved follow-ups" section in the Matrix message for this run. Once the user has been told, strike the line through (`~~...~~`) rather than deleting it — keep the audit history.
+On every subsequent run, before Step 1, scan `TODO.md` for `FOLLOW-UP` items and include an "unresolved follow-ups" section in the audit message. Once the user has been told, strike the line through (`~~...~~`) rather than deleting it — keep the audit history.
 
-## Guidance for yourself
+## Guidance
 
 - Treat the transcript as the source of truth. Don't re-interpret from the filename.
-- Keep Matrix messages short — transcript + category + action taken + archive path.
+- Keep audit messages short — transcript summary + category + confidence + action taken + archive path.
 - When writing GitHub issues or TODO lines, reference the archived transcript path (`data/YYYY/MM/DD/HH-MM-SS-<slug>.md`) rather than the original Voice Memos path — the archive is stable, the source may move or be deleted by iCloud.
-- Never delete or move the source `.m4a`. iCloud owns that lifecycle; archiving is a copy.
-- Don't ask for confirmation before running `INSTRUCTION_DIRECT` — that's what `INSTRUCTION_UNSURE` is for.
-- Always process the steps in order: load → categorize → archive → act → audit. A failed archive never blocks the action step; a failed action never blocks the audit step.
+- Don't ask for confirmation before running `INSTRUCTION_DIRECT` (that's what `INSTRUCTION_UNSURE` is for) — **unless** it involves external communication (see Safety rule 1).
+- Always process the steps in order: load → classify → dedup → archive → act → audit. A failed archive never blocks the action step; a failed action never blocks the audit step.

--- a/install/com.cyclingwithelephants.apple-voice-assistant-healthcheck.plist
+++ b/install/com.cyclingwithelephants.apple-voice-assistant-healthcheck.plist
@@ -3,26 +3,26 @@
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.cyclingwithelephants.apple-voice-assistant</string>
+    <string>com.cyclingwithelephants.apple-voice-assistant-healthcheck</string>
 
     <key>ProgramArguments</key>
     <array>
-        <string>__WATCHER_SCRIPT__</string>
+        <string>__HEALTHCHECK_SCRIPT__</string>
     </array>
 
-    <key>WatchPaths</key>
-    <array>
-        <string>__RECORDINGS_DIR__</string>
-    </array>
-
-    <key>ThrottleInterval</key>
-    <integer>10</integer>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
 
     <key>StandardOutPath</key>
-    <string>__STATE_DIR__/launchd.out.log</string>
+    <string>__STATE_DIR__/healthcheck.out.log</string>
 
     <key>StandardErrorPath</key>
-    <string>__STATE_DIR__/launchd.err.log</string>
+    <string>__STATE_DIR__/healthcheck.err.log</string>
 
     <key>EnvironmentVariables</key>
     <dict>

--- a/install/healthcheck.sh
+++ b/install/healthcheck.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Health check for the apple-voice-assistant launchd watcher.
+# Alerts if the watcher log hasn't been written to in over 24 hours.
+# Install as a daily launchd job or cron entry.
+
+set -euo pipefail
+
+STATE_DIR="${HOME}/.local/state/apple-voice-assistant"
+LOG_FILE="${STATE_DIR}/watcher.log"
+ALERT_FILE="${STATE_DIR}/healthcheck.alert"
+MAX_SILENCE_SECONDS=86400  # 24 hours
+
+if [[ ! -f "${LOG_FILE}" ]]; then
+  echo "WARN: watcher log does not exist at ${LOG_FILE}" >&2
+  exit 1
+fi
+
+last_modified=$(stat -f%m "${LOG_FILE}" 2>/dev/null || echo 0)
+now=$(date +%s)
+age=$(( now - last_modified ))
+
+if (( age > MAX_SILENCE_SECONDS )); then
+  hours=$(( age / 3600 ))
+  msg="apple-voice-assistant watcher has been silent for ${hours}h (last log entry $(date -r "${last_modified}" +%FT%TZ))"
+
+  # Write alert file for other tools to pick up
+  echo "${msg}" > "${ALERT_FILE}"
+
+  # Try to notify via osascript (macOS notification center)
+  if command -v osascript >/dev/null 2>&1; then
+    osascript -e "display notification \"${msg}\" with title \"Voice Assistant Health Check\" sound name \"Basso\"" 2>/dev/null || true
+  fi
+
+  echo "ALERT: ${msg}" >&2
+  exit 1
+else
+  # Clear any previous alert
+  rm -f "${ALERT_FILE}"
+  exit 0
+fi

--- a/install/install.sh
+++ b/install/install.sh
@@ -116,8 +116,8 @@ You can tail the watcher log to confirm:
 
 To uninstall:
 
-  launchctl bootout ${DOMAIN} ${PLIST_DEST}
-  launchctl bootout ${DOMAIN} ${HEALTHCHECK_PLIST_DEST}
+  launchctl bootout "${DOMAIN}" "${PLIST_DEST}"
+  launchctl bootout "${DOMAIN}" "${HEALTHCHECK_PLIST_DEST}"
   rm "${PLIST_DEST}" "${HEALTHCHECK_PLIST_DEST}"
   rm "${SKILL_DIR}"
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -81,8 +81,19 @@ launchctl bootstrap "${DOMAIN}" "${HEALTHCHECK_PLIST_DEST}"
 launchctl enable "${DOMAIN}/${HEALTHCHECK_LABEL}"
 say "Daily health check installed (runs at 09:00)"
 
-# 7. Seed the seen-set with basenames of existing memos (not full paths).
-if [[ ! -s "${STATE_DIR}/seen.txt" ]]; then
+# 7. Seed or migrate the seen-set to basenames.
+# Old installs stored full paths; new format uses basenames only.
+# Detect and migrate, or seed fresh if empty.
+if [[ -s "${STATE_DIR}/seen.txt" ]]; then
+  if head -1 "${STATE_DIR}/seen.txt" | grep -q '/'; then
+    say "Migrating seen-set from full paths to basenames..."
+    while IFS= read -r line; do
+      printf '%s\n' "${line##*/}"
+    done < "${STATE_DIR}/seen.txt" > "${STATE_DIR}/seen.txt.tmp"
+    mv "${STATE_DIR}/seen.txt.tmp" "${STATE_DIR}/seen.txt"
+    say "Migrated seen-set ($(wc -l < "${STATE_DIR}/seen.txt" | tr -d ' ') entries)"
+  fi
+else
   find "${RECORDINGS_DIR}" -maxdepth 1 -name '*.m4a' -type f -exec basename {} \; > "${STATE_DIR}/seen.txt" || true
   say "Seeded seen-set with existing memos ($(wc -l < "${STATE_DIR}/seen.txt" | tr -d ' ') files)"
 fi

--- a/install/install.sh
+++ b/install/install.sh
@@ -15,7 +15,15 @@ PLIST_DEST="${LAUNCH_AGENTS_DIR}/${LABEL}.plist"
 say() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 die() { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
 
+# --- Validate prerequisites ---
 command -v openclaw >/dev/null || die "openclaw not on PATH — install it first (see https://openclaw.ai)"
+command -v gh >/dev/null       || die "gh (GitHub CLI) not on PATH — install it first (brew install gh)"
+command -v osascript >/dev/null || die "osascript not found — this skill requires macOS"
+
+# Check gh auth
+if ! gh auth status &>/dev/null; then
+  die "gh is not authenticated — run 'gh auth login' first (needs 'repo' scope)"
+fi
 
 # 1. Resolve the Voice Memos recordings dir.
 for candidate in \
@@ -41,7 +49,7 @@ ln -s "${REPO_DIR}" "${SKILL_DIR}"
 say "Linked skill: ${SKILL_DIR} -> ${REPO_DIR}"
 
 # 3. Prepare state dir.
-mkdir -p "${STATE_DIR}"
+mkdir -p "${STATE_DIR}" "${STATE_DIR}/processed"
 touch "${STATE_DIR}/seen.txt" "${STATE_DIR}/watcher.log"
 
 # 4. Render the launchd plist with absolute paths.
@@ -61,12 +69,28 @@ DOMAIN="gui/$(id -u)"
 launchctl bootout "${DOMAIN}" "${PLIST_DEST}" 2>/dev/null || true
 launchctl bootstrap "${DOMAIN}" "${PLIST_DEST}"
 launchctl enable "${DOMAIN}/${LABEL}"
-say "launchd job bootstrapped and enabled"
+say "launchd watcher bootstrapped and enabled"
 
-# 6. Seed the seen-set with anything already in the dir so we don't reprocess history.
+# 6. Install daily health check.
+HEALTHCHECK_LABEL="${LABEL}-healthcheck"
+HEALTHCHECK_SCRIPT="${REPO_DIR}/install/healthcheck.sh"
+HEALTHCHECK_PLIST_DEST="${LAUNCH_AGENTS_DIR}/${HEALTHCHECK_LABEL}.plist"
+chmod +x "${HEALTHCHECK_SCRIPT}"
+
+sed \
+  -e "s|__HEALTHCHECK_SCRIPT__|${HEALTHCHECK_SCRIPT}|g" \
+  -e "s|__STATE_DIR__|${STATE_DIR}|g" \
+  "${REPO_DIR}/install/${HEALTHCHECK_LABEL}.plist" > "${HEALTHCHECK_PLIST_DEST}"
+
+launchctl bootout "${DOMAIN}" "${HEALTHCHECK_PLIST_DEST}" 2>/dev/null || true
+launchctl bootstrap "${DOMAIN}" "${HEALTHCHECK_PLIST_DEST}"
+launchctl enable "${DOMAIN}/${HEALTHCHECK_LABEL}"
+say "Daily health check installed (runs at 09:00)"
+
+# 7. Seed the seen-set with basenames of existing memos (not full paths).
 if [[ ! -s "${STATE_DIR}/seen.txt" ]]; then
-  find "${RECORDINGS_DIR}" -maxdepth 1 -name '*.m4a' -type f > "${STATE_DIR}/seen.txt" || true
-  say "Seeded seen-set with existing memos"
+  find "${RECORDINGS_DIR}" -maxdepth 1 -name '*.m4a' -type f -exec basename {} \; > "${STATE_DIR}/seen.txt" || true
+  say "Seeded seen-set with existing memos ($(wc -l < "${STATE_DIR}/seen.txt" | tr -d ' ') files)"
 fi
 
 cat <<EOF
@@ -88,7 +112,8 @@ You can tail the watcher log to confirm:
 To uninstall:
 
   launchctl bootout ${DOMAIN} ${PLIST_DEST}
-  rm "${PLIST_DEST}"
+  launchctl bootout ${DOMAIN} ${HEALTHCHECK_PLIST_DEST}
+  rm "${PLIST_DEST}" "${HEALTHCHECK_PLIST_DEST}"
   rm "${SKILL_DIR}"
 
 EOF

--- a/install/install.sh
+++ b/install/install.sh
@@ -17,13 +17,7 @@ die() { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
 
 # --- Validate prerequisites ---
 command -v openclaw >/dev/null || die "openclaw not on PATH — install it first (see https://openclaw.ai)"
-command -v gh >/dev/null       || die "gh (GitHub CLI) not on PATH — install it first (brew install gh)"
 command -v osascript >/dev/null || die "osascript not found — this skill requires macOS"
-
-# Check gh auth
-if ! gh auth status &>/dev/null; then
-  die "gh is not authenticated — run 'gh auth login' first (needs 'repo' scope)"
-fi
 
 # 1. Resolve the Voice Memos recordings dir.
 for candidate in \

--- a/install/watcher.sh
+++ b/install/watcher.sh
@@ -2,6 +2,11 @@
 # Fires on every change to the Voice Memos iCloud sync dir.
 # Finds new .m4a files (vs. a seen-set of basenames) and hands each one to openclaw.
 # Serialized via mkdir-based lock. Validates file stability before processing.
+#
+# Note: new memos are processed sequentially — each openclaw call can take up to
+# OPENCLAW_TIMEOUT seconds. With multiple new memos this adds up (e.g. 3 memos =
+# up to 15 minutes). This is intentional: serial processing is simpler to reason
+# about for a system that creates reminders, writes to files, and sends messages.
 
 set -euo pipefail
 
@@ -73,38 +78,36 @@ if command -v brctl >/dev/null 2>&1; then
   done
 fi
 
-# --- Batch file stability check ---
-# Snapshot sizes for all .m4a files, sleep once, then recheck.
-# Files whose size changed are still syncing and will be skipped.
-declare -A file_sizes
+# --- Collect unseen files and check stability as a batch ---
+# Only snapshot files not already in the seen-set. Typically 0-2 new files per run,
+# so this avoids stat-ing hundreds of historical memos.
+declare -a new_memos=()
+declare -A new_sizes=()
+
 for memo in "${RECORDINGS_DIR}"/*.m4a; do
   [[ -f "${memo}" ]] || continue
-  file_sizes["${memo}"]=$(stat -f%z "${memo}" 2>/dev/null || echo -1)
+  memo_basename="${memo##*/}"
+  if ! /usr/bin/grep -Fxq "${memo_basename}" "${SEEN_FILE}" 2>/dev/null; then
+    if [[ -s "${memo}" ]]; then
+      new_memos+=("${memo}")
+      new_sizes["${memo}"]=$(stat -f%z "${memo}" 2>/dev/null || echo -1)
+    else
+      log "skipping empty file: ${memo_basename}"
+    fi
+  fi
 done
 
-if (( ${#file_sizes[@]} > 0 )); then
+# Single sleep for the whole batch, only if there are new files
+if (( ${#new_memos[@]} > 0 )); then
   sleep 2
 fi
 
 # --- Process new .m4a files ---
-for memo in "${RECORDINGS_DIR}"/*.m4a; do
-  [[ -f "${memo}" ]] || continue
-
+for memo in "${new_memos[@]}"; do
   memo_basename="${memo##*/}"
 
-  # Check against seen-set (basenames only)
-  if /usr/bin/grep -Fxq "${memo_basename}" "${SEEN_FILE}" 2>/dev/null; then
-    continue
-  fi
-
-  # Skip empty or partial files
-  if [[ ! -s "${memo}" ]]; then
-    log "skipping empty file: ${memo_basename}"
-    continue
-  fi
-
-  # Check file stability from batch snapshot
-  size_before="${file_sizes["${memo}"]:-0}"
+  # Check file stability: size must match pre-sleep snapshot
+  size_before="${new_sizes["${memo}"]:-0}"
   size_now=$(stat -f%z "${memo}" 2>/dev/null || echo -1)
   if [[ "${size_before}" != "${size_now}" ]]; then
     log "file still syncing (size changed ${size_before} -> ${size_now}): ${memo_basename}"
@@ -132,6 +135,9 @@ for memo in "${RECORDINGS_DIR}"/*.m4a; do
   printf '%s\n' "${memo_basename}" >> "${SEEN_FILE}"
 
   # Hand off to openclaw with a PID-targeted timeout.
+  # Note: timer kill targets the specific openclaw PID. On SIGTERM (exit 143),
+  # the || true on kill absorbs errors if the timer already exited. Theoretical
+  # PID recycling risk is accepted (macOS 99999 PID space makes collision negligible).
   /usr/bin/env openclaw agent \
     --message "new voice memo at ${memo}" \
     >> "${LOG_FILE}" 2>&1 &

--- a/install/watcher.sh
+++ b/install/watcher.sh
@@ -1,19 +1,51 @@
 #!/bin/bash
 # Fires on every change to the Voice Memos iCloud sync dir.
-# Finds new .m4a files (vs. a seen-set state file) and hands each one to openclaw.
+# Finds new .m4a files (vs. a seen-set of basenames) and hands each one to openclaw.
+# Serialized via mkdir-based lock. Validates file stability before processing.
 
 set -euo pipefail
 
 STATE_DIR="${HOME}/.local/state/apple-voice-assistant"
 SEEN_FILE="${STATE_DIR}/seen.txt"
 LOG_FILE="${STATE_DIR}/watcher.log"
-mkdir -p "${STATE_DIR}"
+LOCK_DIR="${STATE_DIR}/watcher.lock"
+PROCESSED_DIR="${STATE_DIR}/processed"
+MAX_LOG_BYTES=$((10 * 1024 * 1024))  # 10 MB
+OPENCLAW_TIMEOUT=300                   # 5 minutes
+
+mkdir -p "${STATE_DIR}" "${PROCESSED_DIR}"
 touch "${SEEN_FILE}" "${LOG_FILE}"
 
 log() { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*" >> "${LOG_FILE}"; }
 
-# Resolve the Voice Memos recordings dir. The modern group-container path
-# covers Ventura+; fall back to the legacy Application Support path.
+# --- Log rotation: truncate if over MAX_LOG_BYTES ---
+if [[ -f "${LOG_FILE}" ]]; then
+  log_size=$(stat -f%z "${LOG_FILE}" 2>/dev/null || echo 0)
+  if (( log_size > MAX_LOG_BYTES )); then
+    tail -c $(( MAX_LOG_BYTES / 2 )) "${LOG_FILE}" > "${LOG_FILE}.tmp"
+    mv "${LOG_FILE}.tmp" "${LOG_FILE}"
+    log "rotated log (was ${log_size} bytes)"
+  fi
+fi
+
+# --- Acquire lock (serialize processing, no concurrent runs) ---
+if ! mkdir "${LOCK_DIR}" 2>/dev/null; then
+  # Check for stale lock: if the lock dir is older than OPENCLAW_TIMEOUT*2, remove it
+  if [[ -d "${LOCK_DIR}" ]]; then
+    lock_age=$(( $(date +%s) - $(stat -f%m "${LOCK_DIR}" 2>/dev/null || echo 0) ))
+    if (( lock_age > OPENCLAW_TIMEOUT * 2 )); then
+      log "removing stale lock (age: ${lock_age}s)"
+      rmdir "${LOCK_DIR}" 2>/dev/null || true
+      mkdir "${LOCK_DIR}" 2>/dev/null || { log "still locked after stale removal"; exit 0; }
+    else
+      log "another instance running (lock age: ${lock_age}s), exiting"
+      exit 0
+    fi
+  fi
+fi
+trap 'rmdir "${LOCK_DIR}" 2>/dev/null' EXIT
+
+# --- Resolve the Voice Memos recordings dir ---
 for candidate in \
   "${HOME}/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings" \
   "${HOME}/Library/Application Support/com.apple.voicememos/Recordings"
@@ -29,27 +61,71 @@ if [[ -z "${RECORDINGS_DIR:-}" ]]; then
   exit 1
 fi
 
-# If iCloud has a placeholder (.foo.m4a.icloud) request the actual file.
+# --- Request downloads for iCloud placeholders ---
 shopt -s nullglob
-for placeholder in "${RECORDINGS_DIR}"/.*.m4a.icloud; do
-  log "requesting iCloud download: ${placeholder}"
-  /usr/bin/brctl download "${placeholder}" 2>>"${LOG_FILE}" || true
-done
+if command -v brctl >/dev/null 2>&1; then
+  for placeholder in "${RECORDINGS_DIR}"/.*.m4a.icloud; do
+    log "requesting iCloud download: ${placeholder}"
+    brctl download "${placeholder}" 2>>"${LOG_FILE}" || true
+  done
+fi
 
-# Scan for .m4a files and diff against the seen set.
+# --- Scan for new .m4a files ---
 for memo in "${RECORDINGS_DIR}"/*.m4a; do
   [[ -f "${memo}" ]] || continue
-  if ! /usr/bin/grep -Fxq "${memo}" "${SEEN_FILE}"; then
-    log "new memo: ${memo}"
-    printf '%s\n' "${memo}" >> "${SEEN_FILE}"
 
-    # Hand off to openclaw. Inline file-path pattern — the skill reads the
-    # path out of the message, attaches the audio, and transcribes natively.
-    if ! /usr/bin/env openclaw agent \
-        --message "new voice memo at ${memo}" \
-        >> "${LOG_FILE}" 2>&1
-    then
-      log "ERROR: openclaw invocation failed for ${memo}"
+  basename="${memo##*/}"
+
+  # Validate filename matches expected Voice Memos pattern
+  if [[ ! "${basename}" =~ ^[0-9]{8}\ [0-9]{6}\.m4a$ ]]; then
+    log "WARN: unexpected filename pattern, skipping: ${basename}"
+    continue
+  fi
+
+  # Check against seen-set (basenames only)
+  if /usr/bin/grep -Fxq "${basename}" "${SEEN_FILE}" 2>/dev/null; then
+    continue
+  fi
+
+  # Skip empty or partial files
+  if [[ ! -s "${memo}" ]]; then
+    log "skipping empty file: ${basename}"
+    continue
+  fi
+
+  # Wait for file stability: size must not change over 2 seconds
+  size1=$(stat -f%z "${memo}" 2>/dev/null) || continue
+  sleep 2
+  size2=$(stat -f%z "${memo}" 2>/dev/null) || continue
+  if [[ "${size1}" != "${size2}" ]]; then
+    log "file still syncing (size changed ${size1} -> ${size2}): ${basename}"
+    continue
+  fi
+
+  # Validate audio integrity
+  if command -v afinfo >/dev/null 2>&1; then
+    if ! afinfo "${memo}" &>/dev/null; then
+      log "WARN: afinfo failed, file may be corrupt: ${basename}"
+      continue
     fi
+  fi
+
+  log "new memo: ${basename}"
+
+  # Record in seen-set (basename only, for consistent matching)
+  printf '%s\n' "${basename}" >> "${SEEN_FILE}"
+
+  # Hand off to openclaw with a timeout.
+  # The skill reads the path out of the message, attaches the audio, and transcribes.
+  if ! (
+    # Background kill timer
+    ( sleep "${OPENCLAW_TIMEOUT}"; kill 0 2>/dev/null ) &
+    timer_pid=$!
+    /usr/bin/env openclaw agent \
+      --message "new voice memo at ${memo}" \
+      >> "${LOG_FILE}" 2>&1
+    kill "${timer_pid}" 2>/dev/null
+  ); then
+    log "ERROR: openclaw invocation failed or timed out for ${basename}"
   fi
 done

--- a/install/watcher.sh
+++ b/install/watcher.sh
@@ -18,6 +18,26 @@ touch "${SEEN_FILE}" "${LOG_FILE}"
 
 log() { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*" >> "${LOG_FILE}"; }
 
+# --- Acquire lock (serialize processing, no concurrent runs) ---
+if ! mkdir "${LOCK_DIR}" 2>/dev/null; then
+  if [[ -d "${LOCK_DIR}" ]]; then
+    # Check for stale lock: if older than OPENCLAW_TIMEOUT*2, remove and re-acquire
+    lock_age=$(( $(date +%s) - $(stat -f%m "${LOCK_DIR}" 2>/dev/null || echo 0) ))
+    if (( lock_age > OPENCLAW_TIMEOUT * 2 )); then
+      log "removing stale lock (age: ${lock_age}s)"
+      rm -rf "${LOCK_DIR}"
+      mkdir "${LOCK_DIR}" 2>/dev/null || { log "still locked after stale removal"; exit 0; }
+    else
+      log "another instance running (lock age: ${lock_age}s), exiting"
+      exit 0
+    fi
+  else
+    # Lock dir vanished between mkdir fail and -d check — retry once
+    mkdir "${LOCK_DIR}" 2>/dev/null || { log "lock race, exiting"; exit 0; }
+  fi
+fi
+trap 'rm -rf "${LOCK_DIR}" 2>/dev/null' EXIT
+
 # --- Log rotation: truncate if over MAX_LOG_BYTES ---
 if [[ -f "${LOG_FILE}" ]]; then
   log_size=$(stat -f%z "${LOG_FILE}" 2>/dev/null || echo 0)
@@ -27,23 +47,6 @@ if [[ -f "${LOG_FILE}" ]]; then
     log "rotated log (was ${log_size} bytes)"
   fi
 fi
-
-# --- Acquire lock (serialize processing, no concurrent runs) ---
-if ! mkdir "${LOCK_DIR}" 2>/dev/null; then
-  # Check for stale lock: if the lock dir is older than OPENCLAW_TIMEOUT*2, remove it
-  if [[ -d "${LOCK_DIR}" ]]; then
-    lock_age=$(( $(date +%s) - $(stat -f%m "${LOCK_DIR}" 2>/dev/null || echo 0) ))
-    if (( lock_age > OPENCLAW_TIMEOUT * 2 )); then
-      log "removing stale lock (age: ${lock_age}s)"
-      rmdir "${LOCK_DIR}" 2>/dev/null || true
-      mkdir "${LOCK_DIR}" 2>/dev/null || { log "still locked after stale removal"; exit 0; }
-    else
-      log "another instance running (lock age: ${lock_age}s), exiting"
-      exit 0
-    fi
-  fi
-fi
-trap 'rmdir "${LOCK_DIR}" 2>/dev/null' EXIT
 
 # --- Resolve the Voice Memos recordings dir ---
 for candidate in \
@@ -70,62 +73,77 @@ if command -v brctl >/dev/null 2>&1; then
   done
 fi
 
-# --- Scan for new .m4a files ---
+# --- Batch file stability check ---
+# Snapshot sizes for all .m4a files, sleep once, then recheck.
+# Files whose size changed are still syncing and will be skipped.
+declare -A file_sizes
+for memo in "${RECORDINGS_DIR}"/*.m4a; do
+  [[ -f "${memo}" ]] || continue
+  file_sizes["${memo}"]=$(stat -f%z "${memo}" 2>/dev/null || echo -1)
+done
+
+if (( ${#file_sizes[@]} > 0 )); then
+  sleep 2
+fi
+
+# --- Process new .m4a files ---
 for memo in "${RECORDINGS_DIR}"/*.m4a; do
   [[ -f "${memo}" ]] || continue
 
-  basename="${memo##*/}"
-
-  # Validate filename matches expected Voice Memos pattern
-  if [[ ! "${basename}" =~ ^[0-9]{8}\ [0-9]{6}\.m4a$ ]]; then
-    log "WARN: unexpected filename pattern, skipping: ${basename}"
-    continue
-  fi
+  memo_basename="${memo##*/}"
 
   # Check against seen-set (basenames only)
-  if /usr/bin/grep -Fxq "${basename}" "${SEEN_FILE}" 2>/dev/null; then
+  if /usr/bin/grep -Fxq "${memo_basename}" "${SEEN_FILE}" 2>/dev/null; then
     continue
   fi
 
   # Skip empty or partial files
   if [[ ! -s "${memo}" ]]; then
-    log "skipping empty file: ${basename}"
+    log "skipping empty file: ${memo_basename}"
     continue
   fi
 
-  # Wait for file stability: size must not change over 2 seconds
-  size1=$(stat -f%z "${memo}" 2>/dev/null) || continue
-  sleep 2
-  size2=$(stat -f%z "${memo}" 2>/dev/null) || continue
-  if [[ "${size1}" != "${size2}" ]]; then
-    log "file still syncing (size changed ${size1} -> ${size2}): ${basename}"
+  # Check file stability from batch snapshot
+  size_before="${file_sizes["${memo}"]:-0}"
+  size_now=$(stat -f%z "${memo}" 2>/dev/null || echo -1)
+  if [[ "${size_before}" != "${size_now}" ]]; then
+    log "file still syncing (size changed ${size_before} -> ${size_now}): ${memo_basename}"
     continue
   fi
 
   # Validate audio integrity
   if command -v afinfo >/dev/null 2>&1; then
     if ! afinfo "${memo}" &>/dev/null; then
-      log "WARN: afinfo failed, file may be corrupt: ${basename}"
+      log "WARN: afinfo failed, file may be corrupt: ${memo_basename}"
       continue
     fi
   fi
 
-  log "new memo: ${basename}"
+  # Flag non-standard filenames (renamed memos, non-English locales).
+  # Still process them, but the skill should treat these as medium confidence
+  # since we can't derive a reliable timestamp from the filename.
+  if [[ ! "${memo_basename}" =~ ^[0-9]{8}\ [0-9]{6}\.m4a$ ]]; then
+    log "WARN: non-standard filename, processing with reduced confidence: ${memo_basename}"
+  fi
+
+  log "new memo: ${memo_basename}"
 
   # Record in seen-set (basename only, for consistent matching)
-  printf '%s\n' "${basename}" >> "${SEEN_FILE}"
+  printf '%s\n' "${memo_basename}" >> "${SEEN_FILE}"
 
-  # Hand off to openclaw with a timeout.
-  # The skill reads the path out of the message, attaches the audio, and transcribes.
-  if ! (
-    # Background kill timer
-    ( sleep "${OPENCLAW_TIMEOUT}"; kill 0 2>/dev/null ) &
-    timer_pid=$!
-    /usr/bin/env openclaw agent \
-      --message "new voice memo at ${memo}" \
-      >> "${LOG_FILE}" 2>&1
-    kill "${timer_pid}" 2>/dev/null
-  ); then
-    log "ERROR: openclaw invocation failed or timed out for ${basename}"
+  # Hand off to openclaw with a PID-targeted timeout.
+  /usr/bin/env openclaw agent \
+    --message "new voice memo at ${memo}" \
+    >> "${LOG_FILE}" 2>&1 &
+  oclaw_pid=$!
+  ( sleep "${OPENCLAW_TIMEOUT}"; kill "${oclaw_pid}" 2>/dev/null ) &
+  timer_pid=$!
+  if ! wait "${oclaw_pid}" 2>/dev/null; then
+    log "ERROR: openclaw invocation failed or timed out for ${memo_basename}"
   fi
+  kill "${timer_pid}" 2>/dev/null || true
+  wait "${timer_pid}" 2>/dev/null || true
 done
+
+# --- Heartbeat: always touch the log so healthcheck knows we ran ---
+log "watcher run complete"

--- a/references/actions.md
+++ b/references/actions.md
@@ -1,0 +1,140 @@
+# Actions by State
+
+What to do for each classification state. All actions are subject to the safety rules in SKILL.md Step 5.
+
+## `INSTRUCTION_DIRECT`
+
+Carry out the instruction using your normal tool set (bash, read/write, etc.). When finished — or if you hit a blocker — send an audit message reporting what you did and any result/output.
+
+**Exception**: if the instruction involves sending a message to someone, creating a public resource, or any external communication, treat it as `MESSAGE_DRAFT` (draft + confirm) regardless of confidence.
+
+## `INSTRUCTION_ADD`
+
+Open a GitHub issue on `cyclingwithelephants/skill-apple-voice-assistant` capturing the proposed rule/example. Use `gh issue create` with:
+
+- **title**: one-line summary of the rule (prefix `instruction: `)
+- **body**: full transcript, your interpretation of what the rule means, a suggested patch snippet showing the proposed edit (not just a location reference), and the archived transcript path from Step 4
+
+Before creating, check for existing open issues with similar titles (`gh issue list -s open --search "<keywords>"`) to avoid duplicates.
+
+Send the user a short audit message confirming the issue URL.
+
+## `INSTRUCTION_UNSURE`
+
+Do two things:
+
+1. Send a message quoting the transcript and asking the user to confirm the intended action. Offer the best-guess interpretation.
+2. Follow the `INSTRUCTION_ADD` action to file a GitHub issue proposing an example that would have disambiguated this memo — so next time a similar phrasing lands, you'd classify it confidently. Use the normalized template:
+
+```markdown
+## Type
+
+Edge case / disambiguating example
+
+## Transcript
+
+<full transcript>
+
+## Proposed classification
+
+<your best guess state> (confidence: <level>)
+
+## Suggested example for references/classification-examples.md
+
+| "<key phrase>" | `<STATE>` | <confidence> | <reasoning> |
+
+## Context
+
+<why this was ambiguous, what would make it clear>
+```
+
+Reference the audit message in the issue.
+
+## `TODO_ADAM`
+
+Create an Apple Reminder in the user's default Reminders list (the list Siri uses — don't specify a list name). Use `osascript` with AppleScript:
+
+```applescript
+tell application "Reminders"
+  set newReminder to make new reminder with properties {name:"<short title>", body:"<context/notes>"}
+end tell
+```
+
+Where:
+
+- `name`: a concise imperative title derived from the transcript
+- `body`: any useful context from the memo (who, when, why) — include the full transcript at the bottom so nothing is lost
+
+Send the user an audit message confirming the reminder was added.
+
+## `TODO_ASSISTANT`
+
+Append a line to `TODO.md` at the root of this skill's directory. Format:
+
+```
+- [ ] YYYY-MM-DD <short title> — <one-line context>. Archive: data/YYYY/MM/DD/HH-MM-SS-<slug>.md
+```
+
+If `TODO.md` doesn't exist, create it. Send the user an audit message confirming the task was added.
+
+## `MEMORY_NOTE`
+
+Write the fact to your memory system. The skill says _what_ to remember — the host runtime decides _how_ to store it (e.g. `memory/*.md` files, a knowledge base, structured notes). The memory should be durable and retrievable in future conversations.
+
+Also archive the transcript per Step 4 (the archive is the audit trail; the memory write is the action).
+
+Send the user an audit message confirming what was remembered.
+
+## `JOURNAL_NOTE`
+
+Archive the transcript per Step 4. Tag the archive transcript with `type: journal` in frontmatter. No further action — the archive _is_ the deliverable.
+
+Send the user an audit message confirming the journal entry was archived.
+
+## `IDEA_CAPTURE`
+
+Archive the transcript per Step 4. Tag with `type: idea` in frontmatter.
+
+Append to `IDEAS.md` at the root of this skill's directory:
+
+```
+- YYYY-MM-DD <short title> — <one-line summary>. Archive: data/YYYY/MM/DD/HH-MM-SS-<slug>.md
+```
+
+Send the user an audit message confirming the idea was captured.
+
+## `RESEARCH_REQUEST`
+
+Archive the transcript per Step 4. Tag with `type: research` in frontmatter.
+
+Append to `TODO.md` with a `[research]` prefix:
+
+```
+- [ ] YYYY-MM-DD [research] <topic> — <one-line context>. Archive: data/YYYY/MM/DD/HH-MM-SS-<slug>.md
+```
+
+Do **not** start the research now — just capture the task. Send the user an audit message confirming the research request was filed.
+
+## `MESSAGE_DRAFT`
+
+Archive the transcript per Step 4. Tag with `type: message-draft` in frontmatter.
+
+Draft the message and present it to the user for review. Include:
+
+- Who the message is for
+- The draft message text
+- The channel/medium if mentioned (email, Slack, text, etc.)
+
+**Never send the message.** Wait for explicit user confirmation. Send an audit message with the draft and ask for approval.
+
+## `TRANSCRIBE_ONLY`
+
+Archive the transcript per Step 4. No further action.
+
+Send the user an audit message confirming the transcript was saved.
+
+## `UNKNOWN`
+
+Send the user an audit message containing the full transcript and ask how to categorize it. Include your best-guess classification (if any) and why you weren't confident.
+
+This state feeds the classification training pipeline — memos that land here reveal gaps in the taxonomy or examples. Over time, patterns in `UNKNOWN` memos should drive new `INSTRUCTION_ADD` issues proposing additional states or examples.

--- a/references/actions.md
+++ b/references/actions.md
@@ -10,45 +10,52 @@ Carry out the instruction using your normal tool set (bash, read/write, etc.). W
 
 ## `INSTRUCTION_ADD`
 
-Open a GitHub issue on `cyclingwithelephants/skill-apple-voice-assistant` capturing the proposed rule/example. Use `gh issue create` with:
+The user is proposing a new rule, pattern, or example for this skill. Persist the proposal somewhere the user will review it later. The goal is a durable, reviewable record — not a specific tool or platform.
 
-- **title**: one-line summary of the rule (prefix `instruction: `)
-- **body**: full transcript, your interpretation of what the rule means, a suggested patch snippet showing the proposed edit (not just a location reference), and the archived transcript path from Step 4
+Preferred methods, in order of availability:
 
-Before creating, check for existing open issues with similar titles (`gh issue list -s open --search "<keywords>"`) to avoid duplicates.
+1. **Append to `PROPOSALS.md`** at the root of this skill's directory (always available, no external dependencies)
+2. **Send the user a message** via the audit channel with the full proposal (as a fallback or supplement)
 
-Send the user a short audit message confirming the issue URL.
+Each proposal entry should include:
+
+- **title**: one-line summary of the rule
+- **transcript**: the full memo transcript
+- **interpretation**: your understanding of what the rule means
+- **suggested change**: a concrete patch or example to add (not just a location reference), targeting `SKILL.md` or `references/classification-examples.md`
+- **archive link**: path to the archived transcript from Step 4
+
+Format for `PROPOSALS.md`:
+
+```markdown
+## YYYY-MM-DD — <title>
+
+**Transcript**: <full transcript>
+
+**Interpretation**: <what the rule means>
+
+**Suggested change**:
+<concrete patch or new example row>
+
+**Archive**: data/YYYY/MM/DD/HH-MM-SS-<slug>.md
+**Status**: pending
+```
+
+Before appending, scan existing entries in `PROPOSALS.md` for duplicates (similar title or transcript). If a near-duplicate exists, append a note to the existing entry rather than creating a new one.
+
+Send the user an audit message confirming the proposal was recorded.
 
 ## `INSTRUCTION_UNSURE`
 
 Do two things:
 
 1. Send a message quoting the transcript and asking the user to confirm the intended action. Offer the best-guess interpretation.
-2. Follow the `INSTRUCTION_ADD` action to file a GitHub issue proposing an example that would have disambiguated this memo — so next time a similar phrasing lands, you'd classify it confidently. Use the normalized template:
+2. Follow the `INSTRUCTION_ADD` action to record a proposal for a disambiguating example — so next time a similar phrasing lands, you'd classify it confidently. The proposal should include:
 
-```markdown
-## Type
-
-Edge case / disambiguating example
-
-## Transcript
-
-<full transcript>
-
-## Proposed classification
-
-<your best guess state> (confidence: <level>)
-
-## Suggested example for references/classification-examples.md
-
-| "<key phrase>" | `<STATE>` | <confidence> | <reasoning> |
-
-## Context
-
-<why this was ambiguous, what would make it clear>
-```
-
-Reference the audit message in the issue.
+- The full transcript
+- Your best-guess classification and confidence
+- A suggested example row for `references/classification-examples.md`
+- Why this was ambiguous and what would make it clear
 
 ## `TODO_ADAM`
 

--- a/references/archive-format.md
+++ b/references/archive-format.md
@@ -1,0 +1,82 @@
+# Archive Format
+
+Specification for Step 4 of the skill — archiving audio and transcripts.
+
+## Directory layout
+
+The skill's own directory is at `~/.openclaw/workspace/skills/apple_voice_assistant/` (when installed via symlink). Archive under its `data/` subtree:
+
+```
+data/YYYY/MM/DD/HH-MM-SS-<slug>.m4a      # copy of the original audio
+data/YYYY/MM/DD/HH-MM-SS-<slug>.md       # transcript + metadata
+```
+
+Example: `data/2026/04/19/08-30-45-grocery-list-for-saturday.m4a` + `data/2026/04/19/08-30-45-grocery-list-for-saturday.md`
+
+Create missing intermediate directories with `mkdir -p`. The audio and transcript must share the same `HH-MM-SS-<slug>` stem — never drift.
+
+## Deriving the timestamp
+
+Prefer the timestamp embedded in the Voice Memos filename — the app names recordings like `YYYYMMDD HHMMSS.m4a` (e.g. `20260419 083045.m4a`). Parse out year, month, day, hour, minute, and second, then format as `YYYY/MM/DD` for the directory path and `HH-MM-SS` for the filename prefix.
+
+If the filename doesn't follow that pattern, fall back to the file's mtime via `stat -f %m <path>`.
+
+## Deriving the slug
+
+Generate a short human-readable slug from the transcript so archived files are self-describing at a glance.
+
+Rules:
+
+- 2–6 words, all lowercase, hyphen-separated
+- Describe the topic or action, not the form (good: `grocery-list-for-saturday`, bad: `voice-memo-about-groceries`)
+- Strip all non-ASCII-alphanumeric characters before hyphenating (spaces, punctuation, emoji, accents → gone)
+- Cap total slug length at 50 characters — truncate at the nearest hyphen rather than mid-word
+- If the transcript is too empty or noisy to produce a meaningful slug, use `untitled`
+
+## Audio file
+
+`cp` (never `mv`) from the source path — iCloud owns the Voice Memos file lifecycle and moving would break the app. Preserve the original extension (normally `.m4a`, but derive from the source path, don't assume).
+
+## Transcript file
+
+A Markdown file with YAML frontmatter followed by the full transcript body:
+
+```markdown
+---
+memo_id: "20260419 083045"
+source_path: /Users/adam/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/20260419 083045.m4a
+source_mtime: 1745053845
+source_size_bytes: 234567
+recorded_at: 2026-04-19T08:30:45Z
+archived_at: 2026-04-19T08:31:02Z
+duration_seconds: 47
+category: TODO_ADAM
+confidence: high
+type: memo
+action_taken: created Apple Reminder
+---
+
+<full transcript verbatim>
+```
+
+### Required fields
+
+- `memo_id` — basename without extension, used for dedup
+- `source_path` — absolute path to the original `.m4a`
+- `source_mtime` — Unix timestamp of the source file's mtime
+- `source_size_bytes` — file size in bytes
+- `recorded_at` — derived from filename or mtime
+- `archived_at` — current time when archiving
+- `category` — the classification state
+- `confidence` — high/medium/low
+
+### Optional fields
+
+- `duration_seconds` — audio duration if determinable
+- `type` — semantic tag: `memo` (default), `journal`, `idea`, `research`, `message-draft`
+- `action_taken` — filled in after Step 5 completes (update the file after acting)
+- `transcript_confidence` — if the runtime provides a transcription confidence score
+
+## If archiving fails
+
+If the `cp` or transcript write fails (disk full, permission denied, etc.), log it and continue to Step 5 anyway — the action the user intended should still happen. Include the failure in the audit message.

--- a/references/classification-examples.md
+++ b/references/classification-examples.md
@@ -1,0 +1,44 @@
+# Classification Examples
+
+Worked examples for Step 2 of the skill. This file grows over time as the teaching loop (`INSTRUCTION_ADD`) proposes new patterns.
+
+## Clear cases
+
+| Transcript snippet                                                    | State                | Confidence | Why                                                                 |
+| --------------------------------------------------------------------- | -------------------- | ---------- | ------------------------------------------------------------------- |
+| "Remind me to call the dentist on Thursday"                           | `TODO_ADAM`          | high       | Explicit "remind me" = user's own task                              |
+| "Can you set up a cron job to back up the database every night"       | `INSTRUCTION_DIRECT` | high       | Clear directive to the assistant                                    |
+| "You should always treat YAML changes in the helm chart as high-risk" | `INSTRUCTION_ADD`    | high       | Teaching a new rule for this skill or the assistant's behavior      |
+| "Can you look into why the deploy failed last night"                  | `RESEARCH_REQUEST`   | high       | "Look into" = research, not immediate action                        |
+| "Remember that carrot's ZFS pool is mirrored, not striped"            | `MEMORY_NOTE`        | high       | Concrete fact about infrastructure — persist it                     |
+| "I was thinking about how life has been going lately..."              | `JOURNAL_NOTE`       | high       | Raw reflection, no actionable content                               |
+| "What if we built a CLI that wraps kubectl with project defaults"     | `IDEA_CAPTURE`       | high       | Product/project idea, not an instruction to build it now            |
+| "Tell Sarah I'll be late to dinner"                                   | `MESSAGE_DRAFT`      | high       | "Tell someone" = message draft, **never** send without confirmation |
+| "Just save this, I want a record of what happened at the meeting"     | `TRANSCRIBE_ONLY`    | high       | Explicit "just save this"                                           |
+| "Buy milk, eggs, and bread"                                           | `TODO_ADAM`          | high       | Shopping list = user's own task                                     |
+
+## Ambiguous cases
+
+| Transcript snippet                                               | State                | Confidence | Why                                                                                    |
+| ---------------------------------------------------------------- | -------------------- | ---------- | -------------------------------------------------------------------------------------- |
+| "Fix the nginx config"                                           | `INSTRUCTION_UNSURE` | medium     | Could be direct instruction, but which config? What's broken? Ambiguous scope → UNSURE |
+| "We need to migrate to the new API"                              | `INSTRUCTION_UNSURE` | low        | "We" is ambiguous — is this an instruction or a thought? Low confidence, do not act    |
+| "I think the auth service might be leaking tokens"               | `RESEARCH_REQUEST`   | medium     | Not a direct instruction — sounds like a concern to investigate                        |
+| "Something about the deploy... I dunno, look at it when you can" | `TODO_ASSISTANT`     | medium     | Vague, but clearly delegated ("you... when you can")                                   |
+| "Oh also, Adam's birthday is March 12th"                         | `MEMORY_NOTE`        | high       | Concrete fact about a person                                                           |
+| "Hmm, maybe we should switch to Postgres"                        | `IDEA_CAPTURE`       | medium     | Speculative — capture the idea, don't act on it                                        |
+| "Send... actually never mind, just save this"                    | `TRANSCRIBE_ONLY`    | high       | User explicitly corrected themselves                                                   |
+| "[garbled audio with background noise]"                          | `UNKNOWN`            | low        | Can't determine intent — feeds the classification training pipeline                    |
+
+## Edge cases and biases
+
+| Scenario                                                       | Rule                                                               |
+| -------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Sounds like an instruction but scope is unclear                | `INSTRUCTION_UNSURE` over `INSTRUCTION_DIRECT`                     |
+| Unclear whether user or assistant should do it                 | `TODO_ADAM` over `TODO_ASSISTANT`                                  |
+| A fact embedded inside a rambling reflection                   | `MEMORY_NOTE` over `JOURNAL_NOTE` — extract the fact               |
+| "Can you send X to Y"                                          | `MESSAGE_DRAFT` — **always** draft, never send                     |
+| Memo mentions deletion, financial action, or messaging someone | Even if `INSTRUCTION_DIRECT`, apply Safety rule 1: draft + confirm |
+| Genuinely no signal — garbled, extremely short, or pure noise  | `UNKNOWN` — this is what the training pipeline is for              |
+| User says "just a thought" or "thinking out loud"              | `JOURNAL_NOTE` unless a concrete fact or idea is embedded          |
+| "Add a rule that..." or "from now on..."                       | `INSTRUCTION_ADD` — user is teaching the skill                     |


### PR DESCRIPTION
## Summary

- Expand classification from 6 to 12 states — adds MEMORY_NOTE, JOURNAL_NOTE, IDEA_CAPTURE, RESEARCH_REQUEST, MESSAGE_DRAFT, TRANSCRIBE_ONLY. Documents UNKNOWN as the classification training pipeline (not a fallback bin)
- Add confidence levels (high/medium/low) with enforcement: low confidence never triggers external or irreversible actions
- Harden watcher.sh: serialization lock, file stability check, filename validation, openclaw timeout, log rotation, basename-only seen-set
- Add idempotency/dedup via processed/ state records
- Split SKILL.md into lean core + `references/` (classification examples, actions, archive format)
- Replace hardcoded Matrix with generic audit channel
- Add daily health check (launchd, 09:00, macOS notification if silent >24h)
- Validate all prerequisites in installer (gh, osascript, gh auth)
- Safety rules: draft+confirm for all external sends, low confidence blocks action

Addresses #1 #2 #3 #4 #5 #6 #7 #8 #9 #10 #11 #12 #13 #14 #15 #16 #17 #18

## Test plan

- [ ] Run `./install/install.sh` on a clean Mac — verify prerequisite checks fire for missing `gh`/`osascript`
- [ ] Record a voice memo on iPhone, verify watcher detects it after iCloud sync
- [ ] Verify file stability check: partially synced file should be skipped, then picked up on next watcher fire
- [ ] Verify lock serialization: two rapid watcher fires should not produce duplicate processing
- [ ] Verify openclaw classifies across the new taxonomy (test with memos matching each state)
- [ ] Verify low-confidence classification does not trigger external actions
- [ ] Verify healthcheck fires at 09:00 and alerts if watcher log is stale
- [ ] Verify seen-set basenames match between fresh install seed and watcher runtime