### PR TITLE
docs: add coreutils to prerequisites and install check

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ classify (+ confidence) → dedup check → archive → act → audit
 ## Prerequisites
 
 - macOS (tested on Apple Silicon; should work on Intel)
+- GNU coreutils (`brew install coreutils`) — provides `timeout(1)` used by the watcher
 - [openclaw](https://openclaw.ai) installed and onboarded (`openclaw onboard`)
 - Messaging channel configured in openclaw (`openclaw channels add`) — the skill reports back via your primary channel
 - Voice Memos signed into the same iCloud account as your iPhone, with iCloud sync enabled (System Settings → Apple ID → iCloud → Voice Memos)

--- a/install/install.sh
+++ b/install/install.sh
@@ -18,6 +18,7 @@ die() { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
 # --- Validate prerequisites ---
 command -v openclaw >/dev/null || die "openclaw not on PATH — install it first (see https://openclaw.ai)"
 command -v osascript >/dev/null || die "osascript not found — this skill requires macOS"
+command -v timeout >/dev/null || die "timeout(1) not found — install coreutils: brew install coreutils"
 
 # 1. Resolve the Voice Memos recordings dir.
 for candidate in \


### PR DESCRIPTION
## Summary

- Add `brew install coreutils` to README prerequisites (provides `timeout(1)` used by the watcher)
- Add `command -v timeout` validation in `install.sh` alongside existing `openclaw` and `osascript` checks

Follows up on #21 which switched to `timeout(1)` but didn't update the docs.

## Test plan

- [ ] Run `./install/install.sh` without coreutils — should fail with `timeout(1) not found` error
- [ ] Run `./install/install.sh` with coreutils — should pass prerequisite checks