### PR TITLE
feat: harden Hermes voice memo watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # skill-apple-voice-assistant
 
-An [openclaw](https://openclaw.ai) skill that turns iPhone voice memos into actions.
+An [Hermes](https://Hermes.ai) skill that turns iPhone voice memos into actions.
 
-Record a memo on your phone. iCloud syncs it to your Mac mini. A launchd watcher fires openclaw. openclaw transcribes natively, classifies the intent, and either does the thing, asks you about it, or files it for later — reporting back via your configured messaging channel.
+Record a memo on your phone. iCloud syncs it to your Mac mini. A launchd watcher fires Hermes. Hermes transcribes natively, classifies the intent, and either does the thing, asks you about it, or files it for later — reporting back via your configured messaging channel.
 
 ## What it does
 
@@ -52,9 +52,9 @@ Mac mini: ~/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recording
         ▼
 install/watcher.sh
         │   acquires lock, validates file stability, diffs against seen-set
-        │   emits one openclaw call per new memo (with timeout)
+        │   emits one Hermes call per new memo (with timeout)
         ▼
-openclaw agent --message "new voice memo at <path>"
+hermes chat -q $'Use apple-voice-assistant.\nnew voice memo at <path>'
         │   loads SKILL.md, attaches audio, native Whisper transcribes
         ▼
 classify (+ confidence) → dedup check → archive → act → audit
@@ -63,9 +63,9 @@ classify (+ confidence) → dedup check → archive → act → audit
 ## Prerequisites
 
 - macOS (tested on Apple Silicon; should work on Intel)
-- GNU coreutils (`brew install coreutils`) — provides `timeout(1)` used by the watcher
-- [openclaw](https://openclaw.ai) installed and onboarded (`openclaw onboard`)
-- Messaging channel configured in openclaw (`openclaw channels add`) — the skill reports back via your primary channel
+- GNU coreutils — provides `timeout(1)` used by the watcher. Install it through your system package manager, such as Homebrew or Nix.
+- [Hermes](https://Hermes.ai) installed and onboarded (`Hermes onboard`)
+- Messaging channel configured in Hermes (`Hermes channels add`) — the skill reports back via your primary channel
 - Voice Memos signed into the same iCloud account as your iPhone, with iCloud sync enabled (System Settings → Apple ID → iCloud → Voice Memos)
 - Mac mini stays awake, or is set to wake for network access
 
@@ -79,8 +79,8 @@ cd skill-apple-voice-assistant
 
 The installer:
 
-1. Validates prerequisites (`openclaw`, `osascript`)
-2. Symlinks this repo into `~/.openclaw/workspace/skills/apple_voice_assistant`
+1. Validates prerequisites (`Hermes`, `osascript`)
+2. Symlinks this repo into the active Hermes workspace's `skills/` directory
 3. Renders and bootstraps the launchd watcher (fires on directory changes)
 4. Installs a daily health check (09:00 — alerts if the watcher has gone silent)
 5. Seeds the seen-set with existing memos so your history doesn't get re-processed
@@ -98,12 +98,12 @@ DOMAIN="gui/$(id -u)"
 launchctl bootout "${DOMAIN}" ~/Library/LaunchAgents/com.cyclingwithelephants.apple-voice-assistant.plist
 launchctl bootout "${DOMAIN}" ~/Library/LaunchAgents/com.cyclingwithelephants.apple-voice-assistant-healthcheck.plist
 rm ~/Library/LaunchAgents/com.cyclingwithelephants.apple-voice-assistant*.plist
-rm ~/.openclaw/workspace/skills/apple_voice_assistant
+rm "${HERMES_HOME:-$HOME/.hermes}/skills/apple/apple-voice-assistant"
 ```
 
 ## Teaching it new rules
 
-Record a memo describing the new rule (e.g. "when I say 'remind me to X', always treat that as a `TODO_ADAM`, never `TODO_ASSISTANT`"). If classified as `INSTRUCTION_ADD`, openclaw will append a proposal to `PROPOSALS.md` with a suggested patch for `SKILL.md` or the classification examples. Review, apply, done — next run picks up the new rule.
+Record a memo describing the new rule (e.g. "when I say 'remind me to X', always treat that as a `TODO_ADAM`, never `TODO_ASSISTANT`"). If classified as `INSTRUCTION_ADD`, Hermes will append a proposal to `PROPOSALS.md` with a suggested patch for `SKILL.md` or the classification examples. Review, apply, done — next run picks up the new rule.
 
 Classification examples live in [`references/classification-examples.md`](references/classification-examples.md) and grow over time as the teaching loop proposes new patterns.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -10,16 +10,45 @@ You process iPhone voice memos on behalf of the user (Adam, GitHub `cyclingwithe
 
 > new voice memo at `/absolute/path/to/recording.m4a`
 
+## Step 0 — Watcher/TCC handling on macOS/Nix
+
+The launchd watcher may run without the same TCC privacy grant as an interactive shell. On Adam's Mac/Nix setup, bash globbing, `ls`, and other shell reads of the Voice Memos container can fail even after Python has been granted Full Disk Access / Files & Folders access.
+
+Use the Hermes venv Python explicitly for watcher-side discovery/copy work:
+
+```bash
+/Users/adam/.hermes/hermes-agent/venv/bin/python
+```
+
+Preferred watcher pattern:
+
+1. Use Python to enumerate `/Users/adam/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings`.
+2. Skip directories and `.icloud` placeholders.
+3. Copy the source audio into an unprotected staging directory before invoking shell tools:
+   ```text
+   ~/.local/state/apple-voice-assistant/tmp-audio/
+   ```
+4. Process the staged copy, not the protected Voice Memos path.
+5. Voice Memos may surface new recordings as `.qta`; convert/archive them as normal audio before transcription (the existing watcher has handled `.qta -> .m4a`).
+
 ## Step 1 — Load the audio
 
-Extract the absolute path from the triggering message (e.g. `/Users/adam/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/20260419 083045.m4a`).
+Extract the absolute path from the triggering message (e.g. `/Users/adam/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/20260419 083045.m4a` or a staged copy under `~/.local/state/apple-voice-assistant/tmp-audio/`).
 
-Explicitly read the file and attach it to the conversation so your native audio transcription runs over it. Do not assume the audio is already loaded — call your `read` tool on the path first, then rely on the resulting transcript for the memo body.
+**Transcription priority:**
+1. First check if a synthetic transcript exists at `<m4a-path>.transcript.txt`. If yes, use that directly.
+2. Explicitly read the `.m4a` file first. If the runtime materializes a transcript from that read, use it as the memo body.
+3. If `read` returns raw/binary M4A content, use the local transcription script which implements the priority order:
+   ```bash
+   bash ${HERMES_HOME:-$HOME/.hermes}/skills/apple/apple-voice-assistant/scripts/transcribe.sh /absolute/path/to/recording.m4a /tmp/apple-voice-assistant-transcript.txt
+   ```
+   Then read `/tmp/apple-voice-assistant-transcript.txt`.
+4. If the transcription script fails, send the user a message explaining that transcription failed and stop.
 
 Validate before proceeding:
 
 - path exists and is readable
-- file ends in `.m4a` (skip `.icloud` placeholders — they mean iCloud hasn't finished syncing yet; if you see one, log and stop, the launchd watcher will retry on the next change)
+- file ends in `.m4a` by the time transcription starts (raw `.qta` inputs from Voice Memos should be converted to `.m4a` first; skip `.icloud` placeholders — they mean iCloud hasn't finished syncing yet, and the launchd watcher will retry on the next change)
 - transcript is non-empty
 
 If any check fails, send the user a message explaining the problem and stop.
@@ -135,3 +164,41 @@ On every subsequent run, before Step 1, scan `TODO.md` for `FOLLOW-UP` items and
 - When writing GitHub issues or TODO lines, reference the archived transcript path (`data/YYYY/MM/DD/HH-MM-SS-<slug>.md`) rather than the original Voice Memos path — the archive is stable, the source may move or be deleted by iCloud.
 - Don't ask for confirmation before running `INSTRUCTION_DIRECT` (that's what `INSTRUCTION_UNSURE` is for) — **unless** it involves external communication (see Safety rule 1).
 - Always process the steps in order: load → classify → dedup → archive → act → audit. A failed archive never blocks the action step; a failed action never blocks the audit step.
+
+## Operational watcher notes
+
+- launchd may run the watcher with a sparse environment. Set `HOME`,
+  `HERMES_HOME`, and a `PATH` containing whichever package-manager path provides
+  `timeout` (`/run/current-system/sw/bin`, `/opt/homebrew/bin`, or similar).
+- macOS TCC access to the Voice Memos container can differ between shell tools
+  and Python. The watcher intentionally enumerates and copies Voice Memos with
+  the Hermes Python interpreter, then processes the staged copy from
+  `~/.local/state/apple-voice-assistant/tmp-audio/`.
+- If the Hermes Python path differs from
+  `${HERMES_HOME:-$HOME/.hermes}/hermes-agent/venv/bin/python`, set
+  `APPLE_VOICE_ASSISTANT_PYTHON`.
+- To force a provider/model for the Hermes handoff, set
+  `APPLE_VOICE_ASSISTANT_PROVIDER` and/or `APPLE_VOICE_ASSISTANT_MODEL`.
+  Otherwise the watcher picks an available credential-backed provider from
+  `auth.json`, then falls back to local providers.
+- To force audit delivery to a specific messaging target from non-interactive
+  sessions, set `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`, for example
+  `matrix:!room:example.org`. Without this, the skill asks Hermes to use the
+  configured messaging channel and falls back to stdout.
+
+## End-to-end verification recipe
+
+Use a synthetic memo rather than waiting on iCloud:
+
+1. Copy a known-good Voice Memos audio file (`.qta` is fine) into the Voice Memos recordings directory with a unique filename like `YYYYMMDD HHMMSS-HERMESTEST.qta`.
+2. Add a matching synthetic transcript. If the watcher converts `.qta` to a staged `.m4a`, the transcript must match the staged converted path exactly, including suffix case, for example:
+   ```text
+   ~/.local/state/apple-voice-assistant/tmp-audio/2026-04-25-00-00-01-HERMESTEST.m4a.transcript.txt
+   ```
+3. Remove that basename from `~/.local/state/apple-voice-assistant/seen.txt` and remove any old processed JSON for the same memo id.
+4. Run or kick the watcher, then tail `~/.local/state/apple-voice-assistant/watcher.log` until it prints a session id and final audit.
+5. Verify all three artifacts:
+   - `~/.local/state/apple-voice-assistant/processed/<memo_id>.json`
+   - `~/.hermes/skills/apple/apple-voice-assistant/data/YYYY/MM/DD/<slug>.md`
+   - matching archived `.m4a`
+6. Verify launchd health with `launchctl print gui/$(id -u)/com.cyclingwithelephants.apple-voice-assistant`; `state = not running` with `last exit code = 0` is healthy because this watcher is short-lived.

--- a/install/com.cyclingwithelephants.apple-voice-assistant.plist
+++ b/install/com.cyclingwithelephants.apple-voice-assistant.plist
@@ -15,6 +15,12 @@
         <string>__RECORDINGS_DIR__</string>
     </array>
 
+    <key>StartInterval</key>
+    <integer>10</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
     <key>ThrottleInterval</key>
     <integer>10</integer>
 

--- a/install/healthcheck.sh
+++ b/install/healthcheck.sh
@@ -5,6 +5,9 @@
 
 set -euo pipefail
 
+export HOME="${HOME:-/Users/adam}"
+export PATH="/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
 STATE_DIR="${HOME}/.local/state/apple-voice-assistant"
 LOG_FILE="${STATE_DIR}/watcher.log"
 ALERT_FILE="${STATE_DIR}/healthcheck.alert"

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
-# Installs the apple-voice-assistant openclaw skill and its launchd watcher on a Mac.
+# Installs the apple-voice-assistant Hermes skill and its launchd watcher on a Mac.
 # Safe to re-run: it will replace the existing plist and re-bootstrap.
 
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SKILL_NAME="apple_voice_assistant"
-SKILL_DIR="${HOME}/.openclaw/workspace/skills/${SKILL_NAME}"
 STATE_DIR="${HOME}/.local/state/apple-voice-assistant"
 LAUNCH_AGENTS_DIR="${HOME}/Library/LaunchAgents"
 LABEL="com.cyclingwithelephants.apple-voice-assistant"
@@ -15,10 +13,19 @@ PLIST_DEST="${LAUNCH_AGENTS_DIR}/${LABEL}.plist"
 say() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 die() { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
 
+SKILLS_ROOT="${HERMES_HOME:-${HOME}/.hermes}/skills"
+SKILL_DIR="${SKILLS_ROOT}/apple/apple-voice-assistant"
+
 # --- Validate prerequisites ---
-command -v openclaw >/dev/null || die "openclaw not on PATH — install it first (see https://openclaw.ai)"
+command -v hermes >/dev/null || die "hermes not on PATH — install Hermes Agent first"
 command -v osascript >/dev/null || die "osascript not found — this skill requires macOS"
-command -v timeout >/dev/null || die "timeout(1) not found — install coreutils: brew install coreutils"
+if command -v timeout >/dev/null 2>&1; then
+  :
+elif command -v gtimeout >/dev/null 2>&1; then
+  :
+else
+  die "timeout(1) not found — install coreutils and make sure it is on PATH"
+fi
 
 # 1. Resolve the Voice Memos recordings dir.
 for candidate in \
@@ -32,16 +39,24 @@ do
 done
 [[ -n "${RECORDINGS_DIR:-}" ]] || die "Voice Memos recordings dir not found — open Voice Memos once, record a test memo, then re-run"
 say "Voice Memos dir: ${RECORDINGS_DIR}"
+say "Hermes skills root: ${SKILLS_ROOT}"
 
-# 2. Install the skill by symlinking the repo into openclaw's workspace.
+# 2. Ensure the skill is present in Hermes's active skills tree. If this script
+# is run from elsewhere, link it into the canonical Hermes skills location.
 mkdir -p "$(dirname "${SKILL_DIR}")"
-if [[ -L "${SKILL_DIR}" ]]; then
-  rm "${SKILL_DIR}"
-elif [[ -e "${SKILL_DIR}" ]]; then
-  die "${SKILL_DIR} exists and is not a symlink — move it aside and re-run"
+if [[ "$(cd "${REPO_DIR}" && pwd)" != "$(cd "$(dirname "${SKILL_DIR}")" && pwd)/$(basename "${SKILL_DIR}")" ]]; then
+  if [[ -L "${SKILL_DIR}" ]]; then
+    rm "${SKILL_DIR}"
+  elif [[ -e "${SKILL_DIR}" ]]; then
+    if [[ "$(cd "${SKILL_DIR}" && pwd)" != "${REPO_DIR}" ]]; then
+      die "${SKILL_DIR} exists and is not this repo — move it aside and re-run"
+    fi
+  fi
+  if [[ ! -e "${SKILL_DIR}" ]]; then
+    ln -s "${REPO_DIR}" "${SKILL_DIR}"
+  fi
 fi
-ln -s "${REPO_DIR}" "${SKILL_DIR}"
-say "Linked skill: ${SKILL_DIR} -> ${REPO_DIR}"
+say "Skill available at: ${SKILL_DIR}"
 
 # 3. Prepare state dir.
 mkdir -p "${STATE_DIR}" "${STATE_DIR}/processed"
@@ -95,7 +110,10 @@ if [[ -s "${STATE_DIR}/seen.txt" ]]; then
     say "Migrated seen-set ($(wc -l < "${STATE_DIR}/seen.txt" | tr -d ' ') entries)"
   fi
 else
-  find "${RECORDINGS_DIR}" -maxdepth 1 -name '*.m4a' -type f -exec basename {} \; > "${STATE_DIR}/seen.txt" || true
+  {
+    find "${RECORDINGS_DIR}" -maxdepth 1 -name '*.m4a' -type f -exec basename {} \; || true
+    find "${RECORDINGS_DIR}" -maxdepth 1 -name '*.qta' -type f -exec basename {} \; || true
+  } | sort > "${STATE_DIR}/seen.txt"
   say "Seeded seen-set with existing memos ($(wc -l < "${STATE_DIR}/seen.txt" | tr -d ' ') files)"
 fi
 
@@ -110,7 +128,7 @@ Install complete.
   logs:      ${STATE_DIR}/watcher.log
              ${STATE_DIR}/launchd.{out,err}.log
 
-Record a new voice memo on your iPhone — it should sync to the Mac mini and fire openclaw.
+Record a new voice memo on your iPhone — it should sync to the Mac mini and fire Hermes.
 You can tail the watcher log to confirm:
 
   tail -f "${STATE_DIR}/watcher.log"

--- a/install/watcher.sh
+++ b/install/watcher.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 # Fires on every change to the Voice Memos iCloud sync dir.
-# Finds new .m4a files (vs. a seen-set of basenames) and hands each one to openclaw.
+# Finds new Voice Memos audio files (.m4a and .qta) and hands each one to Hermes.
 # Serialized via mkdir-based lock. Validates file stability before processing.
 #
-# Note: new memos are processed sequentially — each openclaw call can take up to
-# OPENCLAW_TIMEOUT seconds. With multiple new memos this adds up (e.g. 3 memos =
-# up to 15 minutes). This is intentional: serial processing is simpler to reason
-# about for a system that creates reminders, writes to files, and sends messages.
+# Note: new memos are processed sequentially — each Hermes call can take up to
+# HERMES_TIMEOUT seconds. With multiple long memos this queues work rather than
+# running concurrent transcriptions. Intentional: simpler + safer for reminders,
+# files, and outbound audit messages.
 
 set -euo pipefail
+
+export HOME="${HOME:-/Users/adam}"
+export PATH="/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+export HERMES_HOME="${HERMES_HOME:-${HOME}/.hermes}"
 
 STATE_DIR="${HOME}/.local/state/apple-voice-assistant"
 SEEN_FILE="${STATE_DIR}/seen.txt"
@@ -16,25 +20,100 @@ LOG_FILE="${STATE_DIR}/watcher.log"
 LOCK_DIR="${STATE_DIR}/watcher.lock"
 PROCESSED_DIR="${STATE_DIR}/processed"
 MAX_LOG_BYTES=$((10 * 1024 * 1024))  # 10 MB
-OPENCLAW_TIMEOUT=300                   # 5 minutes
+HERMES_TIMEOUT="${APPLE_VOICE_ASSISTANT_HERMES_TIMEOUT:-900}"  # 15 minutes per Hermes attempt
+LOCK_STALE_SECONDS=$((HERMES_TIMEOUT * 4 + 120))  # covers 3 attempts + retry sleeps
+HERMES_SKILL="apple-voice-assistant"
+HERMES_TOOLSETS="file,terminal,messaging,memory,todo"
+PYTHON_BIN="${APPLE_VOICE_ASSISTANT_PYTHON:-${HERMES_HOME}/hermes-agent/venv/bin/python}"
+SELF_CHECK_MODE="${APPLE_VOICE_ASSISTANT_SELF_CHECK:-0}"
+AUDIT_TARGET="${APPLE_VOICE_ASSISTANT_AUDIT_TARGET:-}"
 
-# Require timeout(1) from coreutils (Homebrew: `brew install coreutils`).
-if ! command -v timeout >/dev/null 2>&1; then
-  echo "ERROR: timeout(1) not found. Install coreutils: brew install coreutils" >&2
+# Require timeout(1) from coreutils.
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="$(command -v timeout)"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="$(command -v gtimeout)"
+else
+  echo "ERROR: timeout(1) not found. Ensure coreutils is installed and on PATH." >&2
   exit 1
 fi
 
-mkdir -p "${STATE_DIR}" "${PROCESSED_DIR}"
+TMP_AUDIO_DIR="${STATE_DIR}/tmp-audio"
+
+mkdir -p "${STATE_DIR}" "${PROCESSED_DIR}" "${TMP_AUDIO_DIR}"
 touch "${SEEN_FILE}" "${LOG_FILE}"
 
 log() { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*" >> "${LOG_FILE}"; }
 
+pick_handoff_provider() {
+  if [[ -n "${APPLE_VOICE_ASSISTANT_PROVIDER:-}" || -n "${APPLE_VOICE_ASSISTANT_MODEL:-}" ]]; then
+    printf '%s\t%s\n' "${APPLE_VOICE_ASSISTANT_PROVIDER:-}" "${APPLE_VOICE_ASSISTANT_MODEL:-}"
+    return 0
+  fi
+
+  if [[ ! -f "${HERMES_HOME}/auth.json" ]]; then
+    printf '%s\t%s\n' "llama-local" "qwen3.6-35b-a3b"
+    return 0
+  fi
+
+  if "${PYTHON_BIN}" - "${HERMES_HOME}/auth.json" <<'PY' >/dev/null 2>&1
+import json
+import sys
+from pathlib import Path
+
+auth = json.loads(Path(sys.argv[1]).read_text())
+providers = auth.get("providers", {})
+pool = auth.get("credential_pool", {})
+
+has_codex = bool(providers.get("openai-codex")) or bool(pool.get("openai-codex"))
+sys.exit(0 if has_codex else 1)
+PY
+  then
+    printf '%s\t%s\n' "openai-codex" "gpt-5.5"
+    return 0
+  fi
+
+  if "${PYTHON_BIN}" - "${HERMES_HOME}/auth.json" <<'PY' >/dev/null 2>&1
+import json
+import sys
+from pathlib import Path
+
+auth = json.loads(Path(sys.argv[1]).read_text())
+pool = auth.get("credential_pool", {})
+has_openrouter = bool(pool.get("openrouter"))
+sys.exit(0 if has_openrouter else 1)
+PY
+  then
+    printf '%s\t%s\n' "openrouter" "google/gemini-2.5-flash-preview:free"
+    return 0
+  fi
+
+  printf '%s\t%s\n' "llama-local" "qwen3.6-35b-a3b"
+}
+
+normalized_stem() {
+  local name="$1"
+  if [[ "$name" =~ ^([0-9]{4})([0-9]{2})([0-9]{2})\ ([0-9]{2})([0-9]{2})([0-9]{2})(-(.+))?$ ]]; then
+    local suffix=""
+    if [[ -n "${BASH_REMATCH[8]:-}" ]]; then
+      suffix="-${BASH_REMATCH[8],,}"
+    fi
+    printf '%s-%s-%s-%s-%s-%s%s\n' \
+      "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}" \
+      "${BASH_REMATCH[4]}" "${BASH_REMATCH[5]}" "${BASH_REMATCH[6]}" \
+      "$suffix"
+  else
+    printf '%s\n' "$name" | tr '[:upper:] ' '[:lower:]-'
+  fi
+}
+
 # --- Acquire lock (serialize processing, no concurrent runs) ---
 if ! mkdir "${LOCK_DIR}" 2>/dev/null; then
   if [[ -d "${LOCK_DIR}" ]]; then
-    # Check for stale lock: if older than OPENCLAW_TIMEOUT*2, remove and re-acquire
-    lock_age=$(( $(date +%s) - $(stat -f%m "${LOCK_DIR}" 2>/dev/null || echo 0) ))
-    if (( lock_age > OPENCLAW_TIMEOUT * 2 )); then
+    # Check for stale lock. Must exceed worst-case normal runtime; otherwise
+    # a long transcription can be falsely treated as stale and run concurrently.
+    lock_age=$(( $(date +%s) - $(/usr/bin/stat -f%m "${LOCK_DIR}" 2>/dev/null || echo 0) ))
+    if (( lock_age > LOCK_STALE_SECONDS )); then
       log "removing stale lock (age: ${lock_age}s)"
       rm -rf "${LOCK_DIR}"
       mkdir "${LOCK_DIR}" 2>/dev/null || { log "still locked after stale removal"; exit 0; }
@@ -51,7 +130,7 @@ trap 'rm -rf "${LOCK_DIR}" 2>/dev/null' EXIT
 
 # --- Log rotation: truncate if over MAX_LOG_BYTES ---
 if [[ -f "${LOG_FILE}" ]]; then
-  log_size=$(stat -f%z "${LOG_FILE}" 2>/dev/null || echo 0)
+  log_size=$(/usr/bin/stat -f%z "${LOG_FILE}" 2>/dev/null || echo 0)
   if (( log_size > MAX_LOG_BYTES )); then
     tail -c $(( MAX_LOG_BYTES / 2 )) "${LOG_FILE}" > "${LOG_FILE}.tmp"
     mv "${LOG_FILE}.tmp" "${LOG_FILE}"
@@ -75,52 +154,82 @@ if [[ -z "${RECORDINGS_DIR:-}" ]]; then
   exit 1
 fi
 
-# --- Request downloads for iCloud placeholders ---
-shopt -s nullglob
-if command -v brctl >/dev/null 2>&1; then
-  for placeholder in "${RECORDINGS_DIR}"/.*.m4a.icloud; do
-    log "requesting iCloud download: ${placeholder}"
-    brctl download "${placeholder}" 2>>"${LOG_FILE}" || true
-  done
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  log "ERROR: Hermes Python not found at ${PYTHON_BIN}"
+  exit 1
 fi
 
-# --- Collect unseen files and check stability as a batch ---
-# Only snapshot files not already in the seen-set. Typically 0-2 new files per run,
-# so this avoids stat-ing hundreds of historical memos.
+if [[ "${SELF_CHECK_MODE}" == "1" ]]; then
+  if ! "${PYTHON_BIN}" - "${RECORDINGS_DIR}" <<'PY' >/dev/null 2>&1
+from pathlib import Path
+import sys
+
+recordings = Path(sys.argv[1])
+if not recordings.is_dir():
+    raise SystemExit(1)
+for _ in recordings.iterdir():
+    break
+PY
+  then
+    log "ERROR: watcher self-check failed to enumerate recordings dir"
+    exit 1
+  fi
+  log "watcher self-check ok"
+  exit 0
+fi
+
+# --- Collect unseen files and copy them out of the protected Voice Memos dir ---
+# macOS TCC currently grants the Nix Python runtime access to Voice Memos, while
+# /bin/bash, ls, find, and shell globs can be denied. Keep all directory reads and
+# source-file copying inside Python, then hand only the temp copy to shell tools.
 declare -a new_memos=()
-declare -A new_sizes=()
+declare -a new_sources=()
+declare -a new_sizes=()
 
-for memo in "${RECORDINGS_DIR}"/*.m4a; do
-  [[ -f "${memo}" ]] || continue
-  memo_basename="${memo##*/}"
-  if ! /usr/bin/grep -Fxq "${memo_basename}" "${SEEN_FILE}" 2>/dev/null; then
-    if [[ -s "${memo}" ]]; then
-      new_memos+=("${memo}")
-      new_sizes["${memo}"]=$(stat -f%z "${memo}" 2>/dev/null || echo -1)
-    else
-      log "skipping empty file: ${memo_basename}"
-    fi
-  fi
-done
+discover_file="$(mktemp "${STATE_DIR}/discover.XXXXXX")"
+"${PYTHON_BIN}" - "${RECORDINGS_DIR}" "${SEEN_FILE}" "${TMP_AUDIO_DIR}" >"${discover_file}" 2>>"${LOG_FILE}" <<'PY'
+import shutil, sys, time
+from pathlib import Path
+recordings = Path(sys.argv[1])
+seen_file = Path(sys.argv[2])
+tmp_dir = Path(sys.argv[3])
+seen = set(seen_file.read_text().splitlines()) if seen_file.exists() else set()
+tmp_dir.mkdir(parents=True, exist_ok=True)
+for src in sorted(recordings.iterdir(), key=lambda p: p.stat().st_mtime):
+    if not src.is_file():
+        continue
+    if src.suffix.lower() not in {'.m4a', '.qta'}:
+        continue
+    if src.name in seen:
+        continue
+    st1 = src.stat()
+    if st1.st_size <= 0:
+        continue
+    time.sleep(2)
+    st2 = src.stat()
+    if st1.st_size != st2.st_size:
+        print(f"SYNCING\t{src}\t{st1.st_size}->{st2.st_size}", file=sys.stderr)
+        continue
+    dest = tmp_dir / src.name
+    shutil.copy2(src, dest)
+    print(f"{dest}\t{src}\t{st2.st_size}")
+PY
+while IFS=$'\t' read -r copied source size; do
+  [[ -n "${copied:-}" ]] || continue
+  new_memos+=("${copied}")
+  new_sources+=("${source}")
+  new_sizes+=("${size}")
+done < "${discover_file}"
+rm -f "${discover_file}"
 
-# Single sleep for the whole batch, only if there are new files
-if (( ${#new_memos[@]} > 0 )); then
-  sleep 2
-fi
+# --- Process new audio files ---
+for i in "${!new_memos[@]}"; do
+  memo="${new_memos[$i]}"
+  source_memo="${new_sources[$i]}"
+  memo_basename="${source_memo##*/}"
+  memo_ext="${memo_basename##*.}"
 
-# --- Process new .m4a files ---
-for memo in "${new_memos[@]}"; do
-  memo_basename="${memo##*/}"
-
-  # Check file stability: size must match pre-sleep snapshot
-  size_before="${new_sizes["${memo}"]:-0}"
-  size_now=$(stat -f%z "${memo}" 2>/dev/null || echo -1)
-  if [[ "${size_before}" != "${size_now}" ]]; then
-    log "file still syncing (size changed ${size_before} -> ${size_now}): ${memo_basename}"
-    continue
-  fi
-
-  # Validate audio integrity
+  # Validate audio integrity on the temp copy
   if command -v afinfo >/dev/null 2>&1; then
     if ! afinfo "${memo}" &>/dev/null; then
       log "WARN: afinfo failed, file may be corrupt: ${memo_basename}"
@@ -131,21 +240,76 @@ for memo in "${new_memos[@]}"; do
   # Flag non-standard filenames (renamed memos, non-English locales).
   # Still process them, but the skill should treat these as medium confidence
   # since we can't derive a reliable timestamp from the filename.
-  if [[ ! "${memo_basename}" =~ ^[0-9]{8}\ [0-9]{6}\.m4a$ ]]; then
+  if [[ ! "${memo_basename}" =~ ^[0-9]{8}\ [0-9]{6}(-[A-Z0-9]+)?\.(m4a|qta)$ ]]; then
     log "WARN: non-standard filename, processing with reduced confidence: ${memo_basename}"
+  fi
+
+  memo_id="${memo_basename%.*}"
+  normalized_name="$(normalized_stem "${memo_id}")"
+
+  handoff_path="${memo}"
+  if [[ "${memo_ext}" == "qta" ]]; then
+    converted_m4a="${TMP_AUDIO_DIR}/${normalized_name}.m4a"
+    if afconvert -f m4af -d aac "${memo}" "${converted_m4a}" >/dev/null 2>&1; then
+      handoff_path="${converted_m4a}"
+      log "converted qta to m4a: ${memo_basename} -> ${converted_m4a##*/}"
+    else
+      log "ERROR: failed to convert qta to m4a: ${memo_basename}"
+      continue
+    fi
   fi
 
   log "new memo: ${memo_basename}"
 
-  # Record in seen-set (basename only, for consistent matching)
-  printf '%s\n' "${memo_basename}" >> "${SEEN_FILE}"
+  session_id="apple-voice-assistant:${normalized_name}"
+  IFS=$'\t' read -r HERMES_PROVIDER HERMES_MODEL < <(pick_handoff_provider)
+  provider_args=()
+  if [[ -n "${HERMES_PROVIDER}" ]]; then
+    provider_args+=(--provider "${HERMES_PROVIDER}")
+  fi
+  if [[ -n "${HERMES_MODEL}" ]]; then
+    provider_args+=(--model "${HERMES_MODEL}")
+  fi
+  log "using Hermes provider=${HERMES_PROVIDER:-default} model=${HERMES_MODEL:-default} for ${memo_basename}"
 
-  # Hand off to openclaw with a timeout.
-  if ! timeout "${OPENCLAW_TIMEOUT}" \
-    /usr/bin/env openclaw agent \
-      --message "new voice memo at ${memo}" \
-      >> "${LOG_FILE}" 2>&1; then
-    log "ERROR: openclaw invocation failed or timed out for ${memo_basename}"
+  # Hand off to Hermes with a timeout.
+  # Current Hermes CLI uses `chat -q`; the old OpenClaw flags (--agent,
+  # --session-id, --deliver, --reply-*) no longer exist.
+  prompt=$'new voice memo at `'
+  prompt+="${handoff_path}"
+  prompt+=$'`\n\nProcess it with apple-voice-assistant.'
+  if [[ -n "${AUDIT_TARGET}" ]]; then
+    prompt+=$' At the audit step, send the audit summary using explicit target `'
+    prompt+="${AUDIT_TARGET}"
+    prompt+=$'` if the messaging tool is available; otherwise print the audit summary to stdout.'
+  else
+    prompt+=$' At the audit step, send the audit summary through the configured messaging channel if available; otherwise print the audit summary to stdout.'
+  fi
+
+  handoff_ok=0
+  for attempt in 1 2 3; do
+    if "${TIMEOUT_BIN}" "${HERMES_TIMEOUT}" \
+      "${PYTHON_BIN}" "${HERMES_HOME}/hermes-agent/hermes" chat \
+        --source "apple-voice-assistant" \
+        --skills "${HERMES_SKILL}" \
+        --toolsets "${HERMES_TOOLSETS}" \
+        --pass-session-id \
+        --quiet \
+        "${provider_args[@]}" \
+        --query "${prompt}" \
+        >> "${LOG_FILE}" 2>&1; then
+      handoff_ok=1
+      break
+    fi
+    log "WARN: Hermes handoff failed for ${memo_basename} (attempt ${attempt}/3)"
+    sleep 5
+  done
+  if [[ "${handoff_ok}" -eq 1 ]]; then
+    # Record in seen-set only after Hermes accepted the handoff. If handoff fails,
+    # leave it unseen so a later watcher run can retry.
+    printf '%s\n' "${memo_basename}" >> "${SEEN_FILE}"
+  else
+    log "ERROR: Hermes invocation failed after retries for ${memo_basename}"
   fi
 done
 

--- a/references/archive-format.md
+++ b/references/archive-format.md
@@ -4,7 +4,7 @@ Specification for Step 4 of the skill — archiving audio and transcripts.
 
 ## Directory layout
 
-The skill's own directory is at `~/.openclaw/workspace/skills/apple_voice_assistant/` (when installed via symlink). Archive under its `data/` subtree:
+The skill's own directory is the active Hermes workspace's symlinked skill path, typically `${HERMES_HOME:-$HOME/.hermes}/skills/apple/apple-voice-assistant/`. Archive under its `data/` subtree:
 
 ```
 data/YYYY/MM/DD/HH-MM-SS-<slug>.m4a      # copy of the original audio

--- a/scripts/transcribe.sh
+++ b/scripts/transcribe.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Transcription fallback for apple-voice-assistant skill
+# Priority:
+# 1) synthetic transcript
+# 2) local Whisper API
+# 3) Swift SFSpeechRecognizer
+# 4) mlx-whisper (M4 GPU)
+# 5) faster-whisper (CPU)
+# 6) OpenAI Whisper
+
+set -euo pipefail
+
+AUDIO_FILE="$1"
+OUTPUT_FILE="${2:-/tmp/apple-voice-assistant-transcript.txt}"
+WHISPER_API_BASE="${APPLE_VOICE_ASSISTANT_WHISPER_API_BASE:-http://127.0.0.1:9099}"
+
+# Check for synthetic transcript first
+SYNTHETIC="${AUDIO_FILE}.transcript.txt"
+if [[ -f "$SYNTHETIC" ]]; then
+    cp "$SYNTHETIC" "$OUTPUT_FILE"
+    echo "Using synthetic transcript from $SYNTHETIC" >&2
+    exit 0
+fi
+
+# Prefer a local Whisper API when available.
+if command -v curl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+    if curl -sf --max-time 5 "${WHISPER_API_BASE}/health" >/dev/null 2>&1; then
+        transcript_json="$(mktemp -t apple-voice-assistant-whisper.XXXXXX.json)"
+        trap 'rm -f "$transcript_json"' EXIT
+        if curl -sf --max-time 180 \
+            -F "file=@${AUDIO_FILE}" \
+            "${WHISPER_API_BASE}/v1/audio/transcriptions" >"$transcript_json"; then
+            text="$(jq -r '.text // ""' "$transcript_json" 2>/dev/null || true)"
+            if [[ -n "$text" ]]; then
+                printf '%s\n' "$text" >"$OUTPUT_FILE"
+                echo "Transcribed using local Whisper API at ${WHISPER_API_BASE}" >&2
+                exit 0
+            fi
+        fi
+        rm -f "$transcript_json"
+        trap - EXIT
+    fi
+fi
+
+# Try Swift SFSpeechRecognizer
+SWIFT_SCRIPT="/Users/adam/.hermes/tmp_speech_transcribe.swift"
+if [[ -f "$SWIFT_SCRIPT" ]]; then
+    if swift "$SWIFT_SCRIPT" "$AUDIO_FILE" > "$OUTPUT_FILE" 2>/dev/null; then
+        echo "Transcribed using SFSpeechRecognizer" >&2
+        exit 0
+    fi
+fi
+
+PYTHON_BIN="${APPLE_VOICE_ASSISTANT_PYTHON:-/Users/adam/.hermes/hermes-agent/venv/bin/python}"
+if [[ ! -x "$PYTHON_BIN" ]]; then
+    PYTHON_BIN="$(command -v python3 || true)"
+fi
+
+# Try mlx-whisper (Apple Silicon GPU-accelerated, large-v3-turbo)
+if [[ -n "$PYTHON_BIN" ]] && "$PYTHON_BIN" - <<'PY' >/dev/null 2>&1
+import importlib.util, sys
+sys.exit(0 if importlib.util.find_spec('mlx_whisper') else 1)
+PY
+then
+    if "$PYTHON_BIN" - "$AUDIO_FILE" "$OUTPUT_FILE" <<'PY'
+import sys
+import mlx_whisper
+
+audio_file = sys.argv[1]
+out_file = sys.argv[2]
+result = mlx_whisper.transcribe(
+    audio_file,
+    path_or_hf_repo='mlx-community/whisper-large-v3-turbo',
+)
+text = result['text'].strip()
+if not text:
+    raise SystemExit(1)
+with open(out_file, 'w', encoding='utf-8') as f:
+    f.write(text + '\n')
+lang = result.get('language', 'unknown')
+print(f'mlx-whisper large-v3-turbo lang={lang}', file=sys.stderr)
+PY
+    then
+        echo "Transcribed using mlx-whisper (large-v3-turbo, M4 GPU)" >&2
+        exit 0
+    fi
+fi
+
+# Fallback: faster-whisper (CPU)
+if [[ -n "$PYTHON_BIN" ]] && "$PYTHON_BIN" - <<'PY' >/dev/null 2>&1
+import importlib.util, sys
+sys.exit(0 if importlib.util.find_spec('faster_whisper') else 1)
+PY
+then
+    if "$PYTHON_BIN" - "$AUDIO_FILE" "$OUTPUT_FILE" <<'PY'
+import sys
+from faster_whisper import WhisperModel
+
+audio_file = sys.argv[1]
+out_file = sys.argv[2]
+model = WhisperModel('tiny.en', device='cpu', compute_type='int8')
+segments, info = model.transcribe(audio_file, beam_size=1, vad_filter=True)
+text = ' '.join(seg.text.strip() for seg in segments).strip()
+if not text:
+    raise SystemExit(1)
+with open(out_file, 'w', encoding='utf-8') as f:
+    f.write(text + '\n')
+print(f'{info.language}:{info.language_probability:.3f}', file=sys.stderr)
+PY
+    then
+        echo "Transcribed using faster-whisper" >&2
+        exit 0
+    fi
+fi
+
+# Try OpenAI Whisper API
+if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+    if bash /opt/homebrew/lib/node_modules/Hermes/skills/openai-whisper-api/scripts/transcribe.sh "$AUDIO_FILE" --out "$OUTPUT_FILE" 2>/dev/null; then
+        echo "Transcribed using OpenAI Whisper" >&2
+        exit 0
+    fi
+fi
+
+echo "ERROR: All transcription methods failed" >&2
+exit 1


### PR DESCRIPTION
## Summary\n- update the Apple voice assistant skill for Hermes naming and runtime defaults\n- add portable watcher, healthcheck, installer, and transcription fallbacks\n- make Matrix/audit routing configurable instead of host-specific\n\n## Testing\n- bash -n install/watcher.sh install/healthcheck.sh install/install.sh scripts/transcribe.sh\n- git diff --check\n- consumed from lab-radish via Nix flake input and built with nix build .#darwinConfigurations.radish.system