### PR TITLE
docs: generalize repo for public consumption

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,17 @@ This skill is designed to discover new use cases and evolve its own classificati
 
 When working on this skill, preserve and strengthen this feedback loop. Don't hardcode behaviour that should be learned. Prefer adding classification examples over adding code branches. The goal is an agent that gets better at understanding its user over time without code changes.
 
+## Core design principle: public-repo generality
+
+This is a public, open-source repository. All documentation, code comments, scripts, and skill specs must be written for a general audience — not for a specific machine, user, or deployment.
+
+- **No hardcoded hostnames, usernames, or room IDs.** Use environment variables (`APPLE_VOICE_ASSISTANT_AUDIT_TARGET`, etc.) for anything deployment-specific. The `env` file and webhook registration script are the right places for instance-specific config.
+- **No machine-specific references.** Say "your Mac", not "Mac mini" or a specific hostname. Install instructions should work on any macOS machine, not just one.
+- **"The user", not a name.** Skill specs and action files describe behaviour for whoever deploys the skill.
+- **Nix-darwin examples stay generic.** Reference the module interface (`darwinModules.apple-voice-assistant`), not a specific consuming flake or host config path.
+
+When adding new docs or modifying existing ones, check that nothing leaks a specific deployment's identity into the public repo.
+
 ## Architecture
 
 ```
@@ -88,7 +99,7 @@ shellcheck install/watcher.sh install/healthcheck.sh install/install.sh scripts/
 # Validate Nix flake
 nix flake check --no-build
 
-# Check nix-darwin module builds (requires a consuming flake, e.g. lab-radish)
+# Check nix-darwin module builds (requires a consuming flake)
 # nix build .#darwinConfigurations.<host>.system --no-link
 
 # End-to-end test: place a synthetic .m4a in the recordings dir and watch logs

--- a/README.md
+++ b/README.md
@@ -2,26 +2,26 @@
 
 An [Hermes](https://Hermes.ai) skill that turns iPhone voice memos into actions.
 
-Record a memo on your phone. iCloud syncs it to your Mac mini. A deterministic Python watcher transcribes it, archives it, and fires a webhook to the Hermes gateway. Hermes classifies the intent and either does the thing, asks you about it, or files it for later — reporting back via Matrix.
+Record a memo on your phone. iCloud syncs it to your Mac. A deterministic Python watcher transcribes it, archives it, and fires a webhook to the Hermes gateway. Hermes classifies the intent and either does the thing, asks you about it, or files it for later — reporting back via Matrix.
 
 ## What it does
 
 Each new `.m4a` in your Voice Memos iCloud sync dir is classified into one of twelve states, each with its own action file:
 
-| State                    | Action                                                                 |
-| ------------------------ | ---------------------------------------------------------------------- |
-| `EXTERNAL_MESSAGE_DRAFT` | Draft a message/reply; never send without explicit confirmation        |
-| `REMINDER_OR_ALARM`      | Create a reminder/alarm/list item and log fallback state               |
-| `QUESTION_ANSWER`        | Answer a factual/how-to/explanatory question directly                  |
-| `IMPLEMENTATION_TASK`    | Build/change/test something now, then report                           |
-| `PLANNING_REQUEST`       | Produce a project plan/approach/design                                 |
-| `INSTRUCTION_DIRECT`     | Legacy/general direct instruction not covered by a narrower state      |
-| `INSTRUCTION`            | Record a rule proposal in `PROPOSALS.md` with a suggested patch        |
-| `TODO`                   | Legacy/general task capture — create an Apple Reminder + log TODO.md   |
-| `MEMORY_NOTE`            | Persist a durable fact to Hermes memory                                |
-| `IDEA_CAPTURE`           | Capture a product/project/creative idea in memory                      |
-| `RESEARCH_REQUEST`       | File a research task; do not act immediately                           |
-| `UNKNOWN`                | Message the user for clarification                                     |
+| State                    | Action                                                               |
+| ------------------------ | -------------------------------------------------------------------- |
+| `EXTERNAL_MESSAGE_DRAFT` | Draft a message/reply; never send without explicit confirmation      |
+| `REMINDER_OR_ALARM`      | Create a reminder/alarm/list item and log fallback state             |
+| `QUESTION_ANSWER`        | Answer a factual/how-to/explanatory question directly                |
+| `IMPLEMENTATION_TASK`    | Build/change/test something now, then report                         |
+| `PLANNING_REQUEST`       | Produce a project plan/approach/design                               |
+| `INSTRUCTION_DIRECT`     | Legacy/general direct instruction not covered by a narrower state    |
+| `INSTRUCTION`            | Record a rule proposal in `PROPOSALS.md` with a suggested patch      |
+| `TODO`                   | Legacy/general task capture — create an Apple Reminder + log TODO.md |
+| `MEMORY_NOTE`            | Persist a durable fact to Hermes memory                              |
+| `IDEA_CAPTURE`           | Capture a product/project/creative idea in memory                    |
+| `RESEARCH_REQUEST`       | File a research task; do not act immediately                         |
+| `UNKNOWN`                | Message the user for clarification                                   |
 
 Every classification also carries a **confidence level** (`high`/`medium`/`low`). Low-confidence classifications never trigger external or irreversible actions.
 
@@ -47,7 +47,7 @@ iPhone Voice Memos.app
 iCloud sync
         │
         ▼
-Mac mini: ~/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/
+Mac: ~/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/
         │   launchd WatchPaths fires
         ▼
 scripts/process-memo.py                          ← deterministic, no LLM
@@ -75,20 +75,19 @@ Two decoupled components:
 - Local Whisper API running at `http://127.0.0.1:9099` (for transcription)
 - Messaging channel configured in Hermes — the skill reports back via Matrix
 - Voice Memos signed into the same iCloud account as your iPhone, with iCloud sync enabled (System Settings → Apple ID → iCloud → Voice Memos)
-- Mac mini stays awake, or is set to wake for network access
+- Mac stays awake, or is set to wake for network access
 
 ## Install
 
-On `radish`, do not run the installer. This repo vendors the skill under
-`skills/apple/apple-voice-assistant/`; nix-darwin symlinks it into
-`~/.hermes/skills/apple/apple-voice-assistant` and declares the launchd daemons
-from `hosts/radish/configuration.nix`. After a rebuild, register the webhook:
+### Option A: nix-darwin (declarative)
+
+This repo exports a nix-darwin module via `flake.nix`. Add it to your flake inputs, import `darwinModules.apple-voice-assistant`, and enable the service in your host configuration. After a rebuild, register the webhook:
 
 ```bash
 bash ~/.hermes/skills/apple/apple-voice-assistant/scripts/setup-webhook.sh
 ```
 
-For non-Nix macOS hosts:
+### Option B: manual (any macOS host)
 
 ```bash
 git clone https://github.com/cyclingwithelephants/skill-apple-voice-assistant.git

--- a/SKILL.md
+++ b/SKILL.md
@@ -40,19 +40,19 @@ Assign exactly one **state** and one **confidence level**.
 
 ### States
 
-| State                | Meaning                                                                |
-| -------------------- | ---------------------------------------------------------------------- |
+| State                    | Meaning                                                                                                             |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------- |
 | `EXTERNAL_MESSAGE_DRAFT` | User wants a message/reply drafted for another person or external channel; never send without explicit confirmation |
 | `REMINDER_OR_ALARM`      | Time-sensitive reminder/alarm/shopping-list item; create Apple Reminder/List item and log fallback state            |
-| `QUESTION_ANSWER`        | User asks a factual/how-to/explanatory question; answer directly and archive                                         |
-| `IMPLEMENTATION_TASK`    | User asks you to build/change/test something now; implement or create concrete artifact, then report                 |
+| `QUESTION_ANSWER`        | User asks a factual/how-to/explanatory question; answer directly and archive                                        |
+| `IMPLEMENTATION_TASK`    | User asks you to build/change/test something now; implement or create concrete artifact, then report                |
 | `PLANNING_REQUEST`       | User asks for a project plan/approach/design, not immediate implementation                                          |
 | `INSTRUCTION_DIRECT`     | Legacy/general direct instruction not covered by a narrower state                                                   |
 | `INSTRUCTION`            | User is teaching a new rule, pattern, or example for this skill itself                                              |
 | `TODO`                   | Legacy/general task capture — create an Apple Reminder and log to TODO.md                                           |
 | `MEMORY_NOTE`            | A fact to persist — about a person, project, system, or preference                                                  |
 | `IDEA_CAPTURE`           | A product, project, or creative idea to capture in memory                                                           |
-| `RESEARCH_REQUEST`       | "Look into X" — create a research task, do NOT act immediately                                                     |
+| `RESEARCH_REQUEST`       | "Look into X" — create a research task, do NOT act immediately                                                      |
 | `UNKNOWN`                | No clear intent or ambiguous instruction — message the user                                                         |
 
 `UNKNOWN` is the catch-all. Use it when intent is genuinely unclear, when a memo sounds like an instruction but scope or meaning is ambiguous, or when confidence is too low to act. Always message the user for clarification. Classify into a specific state whenever possible.
@@ -120,7 +120,7 @@ Read that file NOW. Follow its numbered steps. Do NOT skip any step. When the fi
 
 ## Intake status report workflow
 
-Use this when Adam asks for a status report, summary, audit, or "what's actionable" view of voice memo intake.
+Use this when the user asks for a status report, summary, audit, or "what's actionable" view of voice memo intake.
 
 1. Inspect live state, do not answer from memory:
    - `~/.local/state/apple-voice-assistant/data/**/*.md` for archived transcripts, frontmatter category/confidence/type/action_taken, and archive paths
@@ -146,13 +146,13 @@ Use this when Adam asks for a status report, summary, audit, or "what's actionab
 
 ## Operational notes
 
-- **User confirmation requirement.** Adam wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Use `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
+- **User confirmation requirement.** The user wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Use the audit target configured via `APPLE_VOICE_ASSISTANT_AUDIT_TARGET` (set in `~/.local/state/apple-voice-assistant/env` or passed via the webhook subscription's `--deliver-chat-id`). If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
 - **Two-component architecture.** The Python watcher (`scripts/process-memo.py`) runs as a launchd daemon, handles all I/O (discovery, transcription, archiving), and POSTs to the Hermes webhook. You receive the webhook payload and handle classification, action dispatch, and audit.
 - The watcher runs as a LaunchDaemon (starts at boot, before login) — it only does file I/O and webhook POSTs, no GUI access needed. It needs `HOME` set and a `PATH` that includes `/run/current-system/sw/bin`.
 - Voice Memos TCC access: the watcher uses the Hermes venv Python interpreter to enumerate the protected Voice Memos directory, then copies files to `~/.local/state/apple-voice-assistant/tmp-audio/` before processing.
 - Hermes model selection is controlled by `~/.hermes/config.yaml` (default model + `fallback_providers` chain), not by the watcher or webhook config.
 - The webhook subscription is registered by `scripts/setup-webhook.sh`. Run it once after deploying, or re-run when the prompt template changes. Subscriptions persist across gateway restarts.
-- For Matrix audit delivery, use the explicit target `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`.
+- For Matrix audit delivery, use the target configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`.
 
 ## End-to-end verification recipe
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -128,7 +128,7 @@ Install complete.
   logs:      ${STATE_DIR}/watcher.log
              ${STATE_DIR}/launchd.{out,err}.log
 
-Record a new voice memo on your iPhone — it should sync to the Mac mini and fire Hermes.
+Record a new voice memo on your iPhone — it should sync to your Mac and fire Hermes.
 You can tail the watcher log to confirm:
 
   tail -f "${STATE_DIR}/watcher.log"

--- a/install/watcher.sh
+++ b/install/watcher.sh
@@ -33,7 +33,7 @@ HERMES_TOOLSETS="file,terminal,messaging,memory,todo"
 PYTHON_BIN="${APPLE_VOICE_ASSISTANT_PYTHON:-${HERMES_HOME}/hermes-agent/venv/bin/python}"
 SELF_CHECK_MODE="${APPLE_VOICE_ASSISTANT_SELF_CHECK:-0}"
 
-# Require timeout(1) from coreutils. On radish, nix-darwin provides it.
+# Require timeout(1) from coreutils (nix-darwin provides it; on Homebrew: `brew install coreutils`).
 if command -v timeout >/dev/null 2>&1; then
   TIMEOUT_BIN="$(command -v timeout)"
 elif command -v gtimeout >/dev/null 2>&1; then
@@ -222,10 +222,10 @@ for i in "${!new_memos[@]}"; do
 
   # Hand off to Hermes with a timeout. Don't pass --provider or --model;
   # Hermes uses its config.yaml defaults + fallback_providers chain
-  # (openrouter → llama-local/qwen3.6-35b → mlx-radish-local/4B).
+  # Hermes uses its config.yaml defaults + fallback_providers chain.
   prompt=$'new voice memo at `'
   prompt+="${handoff_path}"
-  prompt+=$'`\n\nProcess it with apple-voice-assistant. At the audit step, you MUST send the audit summary to Matrix room !nSlDhIlsFlFubTCaWO:matrix.adamland.xyz using target `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`. If the messaging tool is not available or the send fails, you MUST append a follow-up item to `'"${STATE_DIR}"$'/TODO.md` (see Step 6 in SKILL.md for the exact format). Do NOT silently skip the audit — either deliver it or record the failure.'
+  prompt+=$'`\n\nProcess it with apple-voice-assistant. At the audit step, you MUST send the audit summary to the Matrix room configured in APPLE_VOICE_ASSISTANT_AUDIT_TARGET (`'"${APPLE_VOICE_ASSISTANT_AUDIT_TARGET:-not set}"$'`). If the messaging tool is not available or the send fails, you MUST append a follow-up item to `'"${STATE_DIR}"$'/TODO.md` (see Step 6 in SKILL.md for the exact format). Do NOT silently skip the audit — either deliver it or record the failure.'
 
   handoff_ok=0
   for attempt in 1 2 3; do

--- a/references/action_EXTERNAL_MESSAGE_DRAFT.md
+++ b/references/action_EXTERNAL_MESSAGE_DRAFT.md
@@ -8,7 +8,7 @@ STATE_DIR: `~/.local/state/apple-voice-assistant`
 
 ## Non-negotiable confirmation requirement
 
-Adam wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
+The user wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to the audit target configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
 
 ## Step 1: Draft only
 
@@ -19,7 +19,7 @@ Extract:
 - target platform if stated
 - any ambiguity or missing details
 
-Do **not** send, post, email, or publish. Do **not** use external messaging tools except to send the draft to Adam for confirmation in Matrix.
+Do **not** send, post, email, or publish. Do **not** use external messaging tools except to send the draft to the user for confirmation in Matrix.
 
 ## Step 2: Store pending confirmation
 
@@ -43,6 +43,6 @@ Write `~/.local/state/apple-voice-assistant/processed/<memo_id>.json` with categ
 
 ## Step 5: Audit
 
-Send Adam the draft and explicitly say it was **not sent**. Include recipient/platform, confidence, and archive path.
+Send the user the draft and explicitly say it was **not sent**. Include recipient/platform, confidence, and archive path.
 
 ## DONE

--- a/references/action_IDEA_CAPTURE.md
+++ b/references/action_IDEA_CAPTURE.md
@@ -8,7 +8,7 @@ STATE_DIR: `~/.local/state/apple-voice-assistant`
 
 ## Non-negotiable confirmation requirement
 
-Adam wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
+The user wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to the audit target configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
 
 ## Step 1: Write idea to Hermes memory
 
@@ -51,7 +51,7 @@ Write this JSON to `~/.local/state/apple-voice-assistant/processed/<memo_id>.jso
 
 ## Step: Audit
 
-Send audit summary to Matrix room `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`.
+Send audit summary to the Matrix room configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`.
 If Matrix is unavailable, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md`.
 Include: transcript summary, category, confidence, action taken, archive path.
 

--- a/references/action_IMPLEMENTATION_TASK.md
+++ b/references/action_IMPLEMENTATION_TASK.md
@@ -8,7 +8,7 @@ STATE_DIR: `~/.local/state/apple-voice-assistant`
 
 ## Non-negotiable confirmation requirement
 
-Adam wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
+The user wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to the audit target configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
 
 ## Step 1: Bound the task
 

--- a/references/action_INSTRUCTION.md
+++ b/references/action_INSTRUCTION.md
@@ -8,7 +8,7 @@ STATE_DIR: `~/.local/state/apple-voice-assistant`
 
 ## Non-negotiable confirmation requirement
 
-Adam wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
+The user wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to the audit target configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
 
 ## Step 1: Check for duplicate proposals
 
@@ -72,7 +72,7 @@ Write this JSON to `~/.local/state/apple-voice-assistant/processed/<memo_id>.jso
 
 ## Step: Audit
 
-Send audit summary to Matrix room `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`.
+Send audit summary to the Matrix room configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`.
 If Matrix is unavailable, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md`.
 Include: transcript summary, category, confidence, action taken, archive path.
 

--- a/references/action_INSTRUCTION_DIRECT.md
+++ b/references/action_INSTRUCTION_DIRECT.md
@@ -8,7 +8,7 @@ STATE_DIR: `~/.local/state/apple-voice-assistant`
 
 ## Non-negotiable confirmation requirement
 
-Adam wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
+The user wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to the audit target configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
 
 ## Step 1: Check for external communication
 
@@ -98,7 +98,7 @@ For plan or design requests, `disposition` MUST cite the artifact path created i
 
 ## Step: Audit
 
-Send audit summary to Matrix room `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`.
+Send audit summary to the Matrix room configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`.
 If Matrix is unavailable, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md`.
 Include: transcript summary, category, confidence, action taken, archive path.
 

--- a/references/action_MEMORY_NOTE.md
+++ b/references/action_MEMORY_NOTE.md
@@ -8,7 +8,7 @@ STATE_DIR: `~/.local/state/apple-voice-assistant`
 
 ## Non-negotiable confirmation requirement
 
-Adam wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
+The user wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to the audit target configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
 
 ## Step 1: Write fact to Hermes memory
 
@@ -48,7 +48,7 @@ Write this JSON to `~/.local/state/apple-voice-assistant/processed/<memo_id>.jso
 
 ## Step: Audit
 
-Send audit summary to Matrix room `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`.
+Send audit summary to the Matrix room configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`.
 If Matrix is unavailable, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md`.
 Include: transcript summary, category, confidence, action taken, archive path.
 

--- a/references/action_PLANNING_REQUEST.md
+++ b/references/action_PLANNING_REQUEST.md
@@ -8,7 +8,7 @@ STATE_DIR: `~/.local/state/apple-voice-assistant`
 
 ## Non-negotiable confirmation requirement
 
-Adam wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
+The user wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to the audit target configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
 
 ## Step 1: Do bounded discovery
 

--- a/references/action_QUESTION_ANSWER.md
+++ b/references/action_QUESTION_ANSWER.md
@@ -8,7 +8,7 @@ STATE_DIR: `~/.local/state/apple-voice-assistant`
 
 ## Non-negotiable confirmation requirement
 
-Adam wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
+The user wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to the audit target configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
 
 ## Step 1: Answer the question
 

--- a/references/action_REMINDER_OR_ALARM.md
+++ b/references/action_REMINDER_OR_ALARM.md
@@ -8,7 +8,7 @@ STATE_DIR: `~/.local/state/apple-voice-assistant`
 
 ## Non-negotiable confirmation requirement
 
-Adam wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
+The user wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to the audit target configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
 
 ## Step 1: Interpret destination
 

--- a/references/action_RESEARCH_REQUEST.md
+++ b/references/action_RESEARCH_REQUEST.md
@@ -8,7 +8,7 @@ STATE_DIR: `~/.local/state/apple-voice-assistant`
 
 ## Non-negotiable confirmation requirement
 
-Adam wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
+The user wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to the audit target configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
 
 ## Step 1: Append research item to TODO.md
 
@@ -57,7 +57,7 @@ Write this JSON to `~/.local/state/apple-voice-assistant/processed/<memo_id>.jso
 
 ## Step: Audit
 
-Send audit summary to Matrix room `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`.
+Send audit summary to the Matrix room configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`.
 If Matrix is unavailable, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md`.
 Include: transcript summary, category, confidence, action taken, archive path.
 

--- a/references/action_TODO.md
+++ b/references/action_TODO.md
@@ -8,7 +8,7 @@ STATE_DIR: `~/.local/state/apple-voice-assistant`
 
 ## Non-negotiable confirmation requirement
 
-Adam wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
+The user wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to the audit target configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
 
 ## Step 1: Try Apple Reminder via remindctl (best-effort)
 
@@ -79,7 +79,7 @@ Write this JSON to `~/.local/state/apple-voice-assistant/processed/<memo_id>.jso
 
 ## Step: Audit
 
-Send audit summary to Matrix room `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`.
+Send audit summary to the Matrix room configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`.
 If Matrix is unavailable, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md`.
 Include: transcript summary, category, confidence, action taken, archive path.
 

--- a/references/action_UNKNOWN.md
+++ b/references/action_UNKNOWN.md
@@ -8,7 +8,7 @@ STATE_DIR: `~/.local/state/apple-voice-assistant`
 
 ## Non-negotiable confirmation requirement
 
-Adam wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
+The user wants a Matrix confirmation/audit message every time a voice memo is processed, regardless of category or whether the action succeeded, failed, or only created a draft. Send it to the audit target configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`. If Matrix delivery fails, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md` with enough detail to replay the missed confirmation later.
 
 ## Step 1: Send user the full transcript
 
@@ -68,7 +68,7 @@ Write this JSON to `~/.local/state/apple-voice-assistant/processed/<memo_id>.jso
 
 ## Step: Audit
 
-Send audit summary to Matrix room `matrix:!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`.
+Send audit summary to the Matrix room configured in `APPLE_VOICE_ASSISTANT_AUDIT_TARGET`.
 If Matrix is unavailable, append a FOLLOW-UP line to `~/.local/state/apple-voice-assistant/TODO.md`.
 Include: transcript summary, category, confidence, action taken, archive path.
 

--- a/references/actions.md
+++ b/references/actions.md
@@ -57,7 +57,7 @@ Do two things:
 - A suggested example row for `references/classification-examples.md`
 - Why this was ambiguous and what would make it clear
 
-## `TODO_ADAM`
+## `TODO`
 
 Create an Apple Reminder in the user's default Reminders list (the list Siri uses — don't specify a list name). Use `osascript` with AppleScript:
 

--- a/scripts/setup-webhook.sh
+++ b/scripts/setup-webhook.sh
@@ -13,6 +13,9 @@ STATE_DIR="${HOME}/.local/state/apple-voice-assistant"
 ENV_FILE="${STATE_DIR}/env"
 HERMES="${HERMES_HOME}/hermes-agent/venv/bin/python ${HERMES_HOME}/hermes-agent/hermes"
 
+# Audit target — must be set (e.g. matrix:!roomid:server.example.com)
+: "${APPLE_VOICE_ASSISTANT_AUDIT_TARGET:?Set APPLE_VOICE_ASSISTANT_AUDIT_TARGET to your Matrix room target (e.g. matrix:!roomid:server.example.com)}"
+
 # Remove existing subscription (ignore errors if it doesn't exist)
 $HERMES webhook remove voice-memo 2>/dev/null || true
 
@@ -32,7 +35,7 @@ Transcript:
 Follow SKILL.md. Classify the transcript (Step 2), then STOP and read references/action_<STATE>.md where STATE is your classification. Follow that file step-by-step.' \
   --skills apple-voice-assistant \
   --deliver matrix \
-  --deliver-chat-id '!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz' \
+  --deliver-chat-id "${APPLE_VOICE_ASSISTANT_AUDIT_TARGET#matrix:}" \
   --description 'Process voice memos: classify transcript, act per skill, audit to Matrix' 2>&1)
 
 echo "$output"

--- a/scripts/transcribe.sh
+++ b/scripts/transcribe.sh
@@ -2,7 +2,7 @@
 # Transcription fallback for apple-voice-assistant skill
 # Priority:
 # 1) synthetic transcript
-# 2) local Whisper API managed by radish
+# 2) local Whisper API
 # 3) mlx-whisper (M4 GPU)
 # 4) faster-whisper (CPU)
 # 5) OpenAI Whisper API
@@ -21,7 +21,7 @@ if [[ -f "$SYNTHETIC" ]]; then
     exit 0
 fi
 
-# Prefer the radish-managed local Whisper API when available.
+# Prefer the local Whisper API when available.
 if command -v curl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
     if curl -sf --max-time 5 "${WHISPER_API_BASE}/health" >/dev/null 2>&1; then
         transcript_json="$(mktemp -t apple-voice-assistant-whisper.XXXXXX.json)"


### PR DESCRIPTION
## Summary

- Remove hardcoded references to a specific machine (`radish`, `Mac mini`), user (`Adam`), and Matrix room ID (`!nSlDhIlsFlFubTCaWO:matrix.adamland.xyz`) across 20 files
- Deploy-specific config now flows through `APPLE_VOICE_ASSISTANT_AUDIT_TARGET` env var instead of hardcoded values
- Generalize README install section into Option A (nix-darwin) / Option B (manual) instead of machine-specific instructions
- Add "public-repo generality" design principle to `CLAUDE.md`

## Test plan

- [x] `python3 -m py_compile` passes for all Python scripts
- [x] `shellcheck` clean at warning level
- [x] `nix flake check --no-build` passes
- [ ] Grep for `Adam`, `radish`, `adamland`, `nSlDhIlsFlFubTCaWO` returns zero matches